### PR TITLE
fix: guard against null deserialization in AppStatesService.LoadFile

### DIFF
--- a/Narabemi/Services/ControlFadeManager.cs
+++ b/Narabemi/Services/ControlFadeManager.cs
@@ -84,7 +84,7 @@ namespace Narabemi.Services
 
         public void Receive(ControlsMouseMoveMessage message)
         {
-            _logger.LogTrace("{name}: {value}", nameof(ControlsMouseMoveMessage));
+            _logger.LogTrace("{name}", nameof(ControlsMouseMoveMessage));
 
             _lastMouseMoveTime = DateTime.UtcNow;
             if (!IsVisible)

--- a/Narabemi/Settings/AppStatesService.cs
+++ b/Narabemi/Settings/AppStatesService.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using CommunityToolkit.Diagnostics;
+using Microsoft.Extensions.Logging;
 using Narabemi.UI.Windows;
 
 namespace Narabemi.Settings
@@ -22,17 +23,41 @@ namespace Narabemi.Settings
             WriteIndented = true,
         };
 
+        private readonly ILogger<AppStatesService> _logger;
+
         public AppStates? Current { get; private set; }
 
-        public AppStatesService()
+        public AppStatesService(ILogger<AppStatesService> logger)
         {
+            _logger = logger;
             _opt.Converters.Add(new ColorJsonConverter());
         }
 
         public void LoadFile()
         {
-            var jsonText = File.ReadAllText(FileName);
-            Current = JsonSerializer.Deserialize<AppStates>(jsonText, _opt);
+            if (!File.Exists(FileName))
+            {
+                _logger.LogWarning("{FileName} not found; using default {TypeName}.", FileName, nameof(AppStates));
+                Current = new AppStates();
+                return;
+            }
+
+            try
+            {
+                var jsonText = File.ReadAllText(FileName);
+                Current = JsonSerializer.Deserialize<AppStates>(jsonText, _opt);
+
+                if (Current is null)
+                {
+                    _logger.LogWarning("{FileName} deserialized to null; using default {TypeName}.", FileName, nameof(AppStates));
+                    Current = new AppStates();
+                }
+            }
+            catch (Exception ex) when (ex is IOException or JsonException)
+            {
+                _logger.LogWarning(ex, "Failed to load {FileName}; using default {TypeName}.", FileName, nameof(AppStates));
+                Current = new AppStates();
+            }
         }
 
         public void SaveFile()


### PR DESCRIPTION
## Overview

`AppStatesService.LoadFile()` had no protection against three failure scenarios that could leave `Current` null:

1. The `appstates.json` file does not exist
2. The file contains valid JSON that deserializes to `null` (e.g., the literal `null`)
3. The file is unreadable or contains malformed JSON

Downstream callers use `Guard.IsNotNull(Current)` which throws when `Current` is null, causing an unhandled crash on startup.

## Changes

- **`Narabemi/Settings/AppStatesService.cs`**: Added `ILogger<AppStatesService>` injection and hardened `LoadFile()` with three explicit recovery paths — each falls back to `new AppStates()` and logs a warning.
  - Missing file → log warning, use default
  - Null deserialization result → log warning, use default  
  - `IOException` / `JsonException` → log warning with exception, use default
- **`Narabemi/Services/ControlFadeManager.cs`**: Fixed a pre-existing CA2017 build error (log message template had two placeholders but only one argument on line 87), which was blocking compilation on `origin/main`.

## Testing

- Build passes with 0 errors (`dotnet build`)
- Manual test: placing `null` in `appstates.json` no longer crashes the app; it logs a warning and starts with defaults

Closes #33
