### PR TITLE
fix: store and unregister event handler delegates in MediaElementsManager

### DIFF
--- a/Narabemi/Services/ControlFadeManager.cs
+++ b/Narabemi/Services/ControlFadeManager.cs
@@ -84,7 +84,7 @@ namespace Narabemi.Services
 
         public void Receive(ControlsMouseMoveMessage message)
         {
-            _logger.LogTrace("{name}: {value}", nameof(ControlsMouseMoveMessage));
+            _logger.LogTrace("{name}", nameof(ControlsMouseMoveMessage));
 
             _lastMouseMoveTime = DateTime.UtcNow;
             if (!IsVisible)

--- a/Narabemi/Services/MediaElementsManager.cs
+++ b/Narabemi/Services/MediaElementsManager.cs
@@ -19,6 +19,9 @@ namespace Narabemi.Services
 
         private readonly Dictionary<int, Unosquare.FFME.MediaElement> _mediaElements = new();
         private readonly Dictionary<int, VideoPlayerViewModel> _playerViewModels = new();
+        private readonly Dictionary<int, EventHandler<MediaStateChangedEventArgs>> _mediaStateChangedHandlers = new();
+        private readonly Dictionary<int, EventHandler<MediaOpeningEventArgs>> _mediaOpeningHandlers = new();
+        private readonly Dictionary<int, EventHandler<MediaOpeningEventArgs>> _mediaChangingHandlers = new();
         private readonly ILogger _logger;
         private readonly object _loopLock = new();
 
@@ -97,10 +100,38 @@ namespace Narabemi.Services
             _mediaElements[playerId] = mediaElement;
             _playerViewModels[playerId] = playerViewModel;
 
-            mediaElement.MediaStateChanged += (s, e) => CorrectGlobalPlaybackState();
+            EventHandler<MediaStateChangedEventArgs> mediaStateChangedHandler = (s, e) => CorrectGlobalPlaybackState();
+            EventHandler<MediaOpeningEventArgs> mediaOpeningHandler = (s, e) => e.Options.SubtitlesSource = playerViewModel.SubtitlePath;
+            EventHandler<MediaOpeningEventArgs> mediaChangingHandler = (s, e) => e.Options.SubtitlesSource = playerViewModel.SubtitlePath;
 
-            mediaElement.MediaOpening += (s, e) => e.Options.SubtitlesSource = playerViewModel.SubtitlePath;
-            mediaElement.MediaChanging += (s, e) => e.Options.SubtitlesSource = playerViewModel.SubtitlePath;
+            _mediaStateChangedHandlers[playerId] = mediaStateChangedHandler;
+            _mediaOpeningHandlers[playerId] = mediaOpeningHandler;
+            _mediaChangingHandlers[playerId] = mediaChangingHandler;
+
+            mediaElement.MediaStateChanged += mediaStateChangedHandler;
+            mediaElement.MediaOpening += mediaOpeningHandler;
+            mediaElement.MediaChanging += mediaChangingHandler;
+        }
+
+        public void Unregister(int playerId)
+        {
+            if (_mediaElements.TryGetValue(playerId, out var mediaElement))
+            {
+                if (_mediaStateChangedHandlers.TryGetValue(playerId, out var mediaStateChangedHandler))
+                    mediaElement.MediaStateChanged -= mediaStateChangedHandler;
+
+                if (_mediaOpeningHandlers.TryGetValue(playerId, out var mediaOpeningHandler))
+                    mediaElement.MediaOpening -= mediaOpeningHandler;
+
+                if (_mediaChangingHandlers.TryGetValue(playerId, out var mediaChangingHandler))
+                    mediaElement.MediaChanging -= mediaChangingHandler;
+            }
+
+            _mediaElements.Remove(playerId);
+            _playerViewModels.Remove(playerId);
+            _mediaStateChangedHandlers.Remove(playerId);
+            _mediaOpeningHandlers.Remove(playerId);
+            _mediaChangingHandlers.Remove(playerId);
         }
 
         public async ValueTask PlayAllAsync() =>


### PR DESCRIPTION
## Summary

Closes #30

Event handler lambdas passed to `+=` in `MediaElementsManager.Register()` were anonymous, making it impossible to unsubscribe them. This caused `MediaElement` instances to be held alive by event source references even after the player was no longer in use, preventing garbage collection.

## Changes

**`Narabemi/Services/MediaElementsManager.cs`**
- Add three `Dictionary<int, EventHandler<...>>` fields (`_mediaStateChangedHandlers`, `_mediaOpeningHandlers`, `_mediaChangingHandlers`) to store delegate references keyed by player ID.
- In `Register()`, create named delegate variables before subscribing so references are captured; store them in the new dictionaries.
- Add `Unregister(int playerId)` method that unsubscribes each stored handler from its event on the `MediaElement`, then removes the player's entries from all five dictionaries (`_mediaElements`, `_playerViewModels`, and the three handler dictionaries).

**`Narabemi/Services/ControlFadeManager.cs`**
- Fix pre-existing CA2017 build error: log message template had `{name}: {value}` but only one argument was passed. Removed the unused `{value}` placeholder.

## Testing

Build passes with 0 errors:

```
dotnet build Narabemi/Narabemi.csproj
```

Manual testing: Run the app with `dotnet run --project Narabemi/Narabemi.csproj`, open video files in both players, verify normal playback and sync behavior are unaffected.
