### PR TITLE
fix: sprint integration fixes (conflict-resolved merges + path fixes)

### DIFF
--- a/Narabemi/App.xaml.cs
+++ b/Narabemi/App.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Reflection;
 using System.Threading.Tasks;
 using System.Windows;
@@ -64,7 +65,7 @@ namespace Narabemi
             Host.CreateDefaultBuilder(args)
                 .ConfigureAppConfiguration((context, appConfiguration) =>
                 {
-                    appConfiguration.SetBasePath(context.HostingEnvironment.ContentRootPath);
+                    appConfiguration.SetBasePath(AppContext.BaseDirectory);
                     appConfiguration.AddJsonFile("appsettings.json", false);
                 })
                 .ConfigureLogging(logging =>
@@ -108,7 +109,7 @@ namespace Narabemi
                 var appStateManager = Services.GetRequiredService<Settings.AppStatesService>();
                 appStateManager.LoadFile();
 
-                Unosquare.FFME.Library.FFmpegDirectory = appSettings.FFmpegDirectory;
+                Unosquare.FFME.Library.FFmpegDirectory = Path.GetFullPath(appSettings.FFmpegDirectory, AppContext.BaseDirectory);
                 logger.LogInformation("{Name}: '{FFmpegDirectory}'", nameof(appSettings.FFmpegDirectory), appSettings.FFmpegDirectory);
 
                 // Start Generic Host

--- a/Narabemi/Services/ControlFadeManager.cs
+++ b/Narabemi/Services/ControlFadeManager.cs
@@ -75,16 +75,14 @@ namespace Narabemi.Services
                 var elapsed = e.SignalTime.ToUniversalTime() - _lastMouseMoveTime;
                 if (elapsed > _hideStartDuration)
                 {
-                    // IsMouseOver is a WPF DependencyProperty and must be read on the UI thread.
-                    var isHovered = false;
+                    // IsMouseOver is a WPF DependencyProperty — read it and conditionally
+                    // send the hide message atomically on the UI thread.
                     await UIThread.TryInvokeAsync(() =>
                     {
-                        isHovered = _mouseHoverTargets.Any(v => v.IsMouseOver);
+                        if (!_mouseHoverTargets.Any(v => v.IsMouseOver))
+                            WeakReferenceMessenger.Default.Send(new ControlsVisibilityMessage(false));
                         return ValueTask.CompletedTask;
                     });
-
-                    if (!isHovered)
-                        WeakReferenceMessenger.Default.Send(new ControlsVisibilityMessage(false));
                 }
             }
             else

--- a/Narabemi/Services/MediaElementsManager.cs
+++ b/Narabemi/Services/MediaElementsManager.cs
@@ -22,6 +22,11 @@ namespace Narabemi.Services
 
         private readonly ConcurrentDictionary<int, Unosquare.FFME.MediaElement> _mediaElements = new();
         private readonly ConcurrentDictionary<int, VideoPlayerViewModel> _playerViewModels = new();
+        private readonly ConcurrentDictionary<int, EventHandler<MediaStateChangedEventArgs>> _mediaStateChangedHandlers = new();
+        private readonly ConcurrentDictionary<int, EventHandler<MediaOpeningEventArgs>> _mediaOpeningHandlers = new();
+        private readonly ConcurrentDictionary<int, EventHandler<MediaOpeningEventArgs>> _mediaChangingHandlers = new();
+        private readonly ConcurrentDictionary<int, EventHandler> _mediaEndedHandlers = new();
+        private readonly object _loopLock = new();
         private readonly ILogger _logger;
 
         public MediaElementsManager(ILogger<MediaElementsManager> logger)
@@ -120,12 +125,11 @@ namespace Narabemi.Services
             _mediaElements[playerId] = mediaElement;
             _playerViewModels[playerId] = playerViewModel;
 
-            mediaElement.MediaStateChanged += (s, e) => CorrectGlobalPlaybackState();
+            EventHandler<MediaStateChangedEventArgs> mediaStateChangedHandler = (s, e) => CorrectGlobalPlaybackState();
+            EventHandler<MediaOpeningEventArgs> mediaOpeningHandler = (s, e) => e.Options.SubtitlesSource = playerViewModel.SubtitlePath;
+            EventHandler<MediaOpeningEventArgs> mediaChangingHandler = (s, e) => e.Options.SubtitlesSource = playerViewModel.SubtitlePath;
 
-            mediaElement.MediaOpening += (s, e) => e.Options.SubtitlesSource = playerViewModel.SubtitlePath;
-            mediaElement.MediaChanging += (s, e) => e.Options.SubtitlesSource = playerViewModel.SubtitlePath;
-
-            mediaElement.MediaEnded += async (s, e) =>
+            EventHandler mediaEndedHandler = async (s, e) =>
             {
                 if (!Loop)
                     return;
@@ -144,6 +148,41 @@ namespace Narabemi.Services
                     Monitor.Exit(_loopLock);
                 }
             };
+
+            _mediaStateChangedHandlers[playerId] = mediaStateChangedHandler;
+            _mediaOpeningHandlers[playerId] = mediaOpeningHandler;
+            _mediaChangingHandlers[playerId] = mediaChangingHandler;
+            _mediaEndedHandlers[playerId] = mediaEndedHandler;
+
+            mediaElement.MediaStateChanged += mediaStateChangedHandler;
+            mediaElement.MediaOpening += mediaOpeningHandler;
+            mediaElement.MediaChanging += mediaChangingHandler;
+            mediaElement.MediaEnded += mediaEndedHandler;
+        }
+
+        public void Unregister(int playerId)
+        {
+            if (_mediaElements.TryGetValue(playerId, out var mediaElement))
+            {
+                if (_mediaStateChangedHandlers.TryGetValue(playerId, out var mediaStateChangedHandler))
+                    mediaElement.MediaStateChanged -= mediaStateChangedHandler;
+
+                if (_mediaOpeningHandlers.TryGetValue(playerId, out var mediaOpeningHandler))
+                    mediaElement.MediaOpening -= mediaOpeningHandler;
+
+                if (_mediaChangingHandlers.TryGetValue(playerId, out var mediaChangingHandler))
+                    mediaElement.MediaChanging -= mediaChangingHandler;
+
+                if (_mediaEndedHandlers.TryGetValue(playerId, out var mediaEndedHandler))
+                    mediaElement.MediaEnded -= mediaEndedHandler;
+            }
+
+            _mediaElements.TryRemove(playerId, out _);
+            _playerViewModels.TryRemove(playerId, out _);
+            _mediaStateChangedHandlers.TryRemove(playerId, out _);
+            _mediaOpeningHandlers.TryRemove(playerId, out _);
+            _mediaChangingHandlers.TryRemove(playerId, out _);
+            _mediaEndedHandlers.TryRemove(playerId, out _);
         }
 
         public async ValueTask PlayAllAsync() =>

--- a/Narabemi/Services/MediaElementsManager.cs
+++ b/Narabemi/Services/MediaElementsManager.cs
@@ -122,6 +122,8 @@ namespace Narabemi.Services
 
         public void Register(int playerId, Unosquare.FFME.MediaElement mediaElement, VideoPlayerViewModel playerViewModel)
         {
+            Unregister(playerId);
+
             _mediaElements[playerId] = mediaElement;
             _playerViewModels[playerId] = playerViewModel;
 

--- a/Narabemi/Settings/AppStatesService.cs
+++ b/Narabemi/Settings/AppStatesService.cs
@@ -46,6 +46,12 @@ namespace Narabemi.Settings
             {
                 var jsonText = File.ReadAllText(FileName);
                 Current = JsonSerializer.Deserialize<AppStates>(jsonText, _opt);
+
+                if (Current is null)
+                {
+                    _logger.LogWarning("{FileName} deserialized to null; using default {TypeName}.", FileName, nameof(AppStates));
+                    Current = new AppStates();
+                }
             }
             catch (Exception ex) when (ex is IOException or JsonException)
             {

--- a/Narabemi/UI/Windows/MainWindow.xaml.cs
+++ b/Narabemi/UI/Windows/MainWindow.xaml.cs
@@ -6,13 +6,13 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
+using System.IO;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Narabemi.Models;
 using Narabemi.Services;
@@ -117,6 +117,7 @@ namespace Narabemi.UI.Windows
         private readonly Settings.AppStatesService _appState;
         private readonly MediaElementsManager _mediaElementsManager;
         private readonly ControlFadeManager _controlFadeManager;
+        private readonly VersionWindowViewModel _versionWindowViewModel;
         private readonly object _lockObj = new();
         private readonly DispatcherTimer _autoSyncTimer;
 
@@ -125,13 +126,15 @@ namespace Narabemi.UI.Windows
             IConfiguration conf,
             Settings.AppStatesService appState,
             MediaElementsManager mediaElementsManager,
-            ControlFadeManager controlFadeManager)
+            ControlFadeManager controlFadeManager,
+            VersionWindowViewModel versionWindowViewModel)
         {
             _logger = logger;
             _appSettings = conf.Get<Settings.AppSettings>();
             _appState = appState;
             _mediaElementsManager = mediaElementsManager;
             _controlFadeManager = controlFadeManager;
+            _versionWindowViewModel = versionWindowViewModel;
 
             MainPlayerIndex = 0;
 
@@ -161,20 +164,26 @@ namespace Narabemi.UI.Windows
         partial void OnLoopChanged(bool value) =>
             _mediaElementsManager.Loop = value;
 
-        partial void OnGlobalPlaybackStateChanged(GlobalPlaybackState value)
+        async partial void OnGlobalPlaybackStateChanged(GlobalPlaybackState value)
         {
             switch (value)
             {
-                case GlobalPlaybackState.Play: _mediaElementsManager?.PlayAllAsync(); break;
-                case GlobalPlaybackState.Pause: _mediaElementsManager?.PauseAllAsync(); break;
-                case GlobalPlaybackState.Stop: _mediaElementsManager?.StopAllAsync(); break;
+                case GlobalPlaybackState.Play:
+                    if (_mediaElementsManager != null) await _mediaElementsManager.PlayAllAsync();
+                    break;
+                case GlobalPlaybackState.Pause:
+                    if (_mediaElementsManager != null) await _mediaElementsManager.PauseAllAsync();
+                    break;
+                case GlobalPlaybackState.Stop:
+                    if (_mediaElementsManager != null) await _mediaElementsManager.StopAllAsync();
+                    break;
             }
 
-            if (AutoSync && value == GlobalPlaybackState.Pause)
-                _mediaElementsManager?.SimpleSync();
+            if (AutoSync && value == GlobalPlaybackState.Pause && _mediaElementsManager != null)
+                await _mediaElementsManager.SimpleSync();
         }
 
-        partial void OnAutoSyncChanged(bool value)
+        async partial void OnAutoSyncChanged(bool value)
         {
             _mediaElementsManager.AutoSync = value;
 
@@ -185,8 +194,8 @@ namespace Narabemi.UI.Windows
             else
             {
                 _autoSyncTimer.Stop();
-                if (GlobalPlaybackState == GlobalPlaybackState.Pause)
-                    _mediaElementsManager?.SimpleSync();
+                if (GlobalPlaybackState == GlobalPlaybackState.Pause && _mediaElementsManager != null)
+                    await _mediaElementsManager.SimpleSync();
 
                 _mediaElementsManager?.ResetAllSpeed();
             }
@@ -207,7 +216,7 @@ namespace Narabemi.UI.Windows
         [RelayCommand]
         private void Loaded()
         {
-            ShaderFilePath = _appSettings.ShaderPath;
+            ShaderFilePath = Path.GetFullPath(_appSettings.ShaderPath, AppContext.BaseDirectory);
             _appState.ApplyTo(this);
         }
 
@@ -248,18 +257,13 @@ namespace Narabemi.UI.Windows
         [RelayCommand] private void SetLayoutComparisonSliderView() => SetLayout(0.0, 1.0);
 
         [RelayCommand]
-        private static void ShowVersion()
+        private void ShowVersion()
         {
-            var mainWindow = App.Services?.GetRequiredService<MainWindow>();
-            var viewModel = App.Services?.GetRequiredService<VersionWindowViewModel>();
-            if (viewModel != null)
+            var versionWindow = new VersionWindow(_versionWindowViewModel)
             {
-                var versionWindow = new VersionWindow(viewModel)
-                {
-                    Owner = mainWindow
-                };
-                versionWindow.ShowDialog();
-            }
+                Owner = Application.Current.MainWindow
+            };
+            versionWindow.ShowDialog();
         }
 
         private void SetLayout(double sideBySideViewHeight, double sliderComparisonViewHeight)


### PR DESCRIPTION
## Summary

Several sprint PRs modified the same files and needed conflict resolution during verify-sprint. This PR captures the integrated, conflict-resolved state for 5 files that still differ from `origin/main` after the individual PRs were squash-merged:

- **`App.xaml.cs`**: Use `AppContext.BaseDirectory` as base for `appsettings.json` and FFmpeg directory resolution — fixes startup failure when the app is launched from a different working directory
- **`ControlFadeManager.cs`**: Move `WeakReferenceMessenger.Send(ControlsVisibilityMessage)` inside the `UIThread.TryInvokeAsync` lambda so the `IsMouseOver` check and the message send are atomic — fixes a race condition from PR #12 / #18
- **`MediaElementsManager.cs`**: Combine ConcurrentDictionary refactor (PR #51) with event handler storage dicts + `Unregister()` method (PR #30) and `_loopLock` for loop playback (PR #38) — all three PRs touched the same class
- **`AppStatesService.cs`**: Add null-deserialization guard (missed when PR #50 and PR #33 were merged individually)
- **`MainWindow.xaml.cs`**: Combine VersionWindow DI injection (PR #11), shader path fix via `AppContext.BaseDirectory`, and `async partial void` await fixes for `ValueTask` calls (PR #36 / #20)

These changes were verified together in the `verify/sprint-2026-04-03` branch and confirmed working (app starts, video plays, version window opens).

## Test plan

- [ ] Build: `dotnet build Narabemi/Narabemi.csproj`
- [ ] Launch app from a directory other than the project root — verify it starts without "appsettings.json not found" error
- [ ] Drag a video file onto each player — verify playback works
- [ ] Click the version icon — verify VersionWindow opens
- [ ] Toggle Loop — verify loop playback restarts from beginning

🤖 Generated with [Claude Code](https://claude.com/claude-code)