### PR TITLE
refactor: decouple MediaElementsManager from MainWindowViewModel via messaging

### DIFF
--- a/Narabemi/Messages/PlaybackStateChangedMessage.cs
+++ b/Narabemi/Messages/PlaybackStateChangedMessage.cs
@@ -1,0 +1,10 @@
+using CommunityToolkit.Mvvm.Messaging.Messages;
+using Narabemi.Models;
+
+namespace Narabemi.Messages
+{
+    public class PlaybackStateChangedMessage : ValueChangedMessage<GlobalPlaybackState>
+    {
+        public PlaybackStateChangedMessage(GlobalPlaybackState state) : base(state) { }
+    }
+}

--- a/Narabemi/Services/MediaElementsManager.cs
+++ b/Narabemi/Services/MediaElementsManager.cs
@@ -7,8 +7,8 @@ using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.Messaging;
 using Microsoft.Extensions.Logging;
 using Narabemi.Messages;
+using Narabemi.Models;
 using Narabemi.UI.Controls;
-using Narabemi.UI.Windows;
 using Unosquare.FFME.Common;
 
 namespace Narabemi.Services
@@ -18,7 +18,8 @@ namespace Narabemi.Services
         public int MainPlayerId { get; set; }
         public bool AutoSync { get; set; }
         public bool Loop { get; set; }
-        public MainWindowViewModel? MainWindowViewModel { get; set; } = null;
+
+        private GlobalPlaybackState _lastKnownPlaybackState = GlobalPlaybackState.Init;
 
         private readonly ConcurrentDictionary<int, Unosquare.FFME.MediaElement> _mediaElements = new();
         private readonly ConcurrentDictionary<int, VideoPlayerViewModel> _playerViewModels = new();
@@ -56,7 +57,7 @@ namespace Narabemi.Services
                                 var position = targetMe.Position;
                                 if (await targetMe.Close() && await targetMe.Open(source))
                                 {
-                                    if (r.MainWindowViewModel?.GlobalPlaybackState == GlobalPlaybackState.Play)
+                                    if (r._lastKnownPlaybackState == GlobalPlaybackState.Play)
                                     {
                                         await targetMe.Play();
                                     }
@@ -278,18 +279,21 @@ namespace Narabemi.Services
 
         private void CorrectGlobalPlaybackState()
         {
-            if (MainWindowViewModel == null)
-                return;
-
             var mediaStates = _mediaElements.Values.Select(v => v.MediaState);
 
-            var vm = MainWindowViewModel;
-            if (vm.GlobalPlaybackState != GlobalPlaybackState.Play && mediaStates.All(v => v == MediaPlaybackState.Play))
-                vm.GlobalPlaybackState = GlobalPlaybackState.Play;
-            else if (vm.GlobalPlaybackState != GlobalPlaybackState.Pause && mediaStates.All(v => v == MediaPlaybackState.Pause))
-                vm.GlobalPlaybackState = GlobalPlaybackState.Pause;
-            else if (vm.GlobalPlaybackState != GlobalPlaybackState.Stop && mediaStates.All(v => v == MediaPlaybackState.Stop))
-                vm.GlobalPlaybackState = GlobalPlaybackState.Stop;
+            GlobalPlaybackState? newState = null;
+            if (_lastKnownPlaybackState != GlobalPlaybackState.Play && mediaStates.All(v => v == MediaPlaybackState.Play))
+                newState = GlobalPlaybackState.Play;
+            else if (_lastKnownPlaybackState != GlobalPlaybackState.Pause && mediaStates.All(v => v == MediaPlaybackState.Pause))
+                newState = GlobalPlaybackState.Pause;
+            else if (_lastKnownPlaybackState != GlobalPlaybackState.Stop && mediaStates.All(v => v == MediaPlaybackState.Stop))
+                newState = GlobalPlaybackState.Stop;
+
+            if (newState.HasValue)
+            {
+                _lastKnownPlaybackState = newState.Value;
+                WeakReferenceMessenger.Default.Send(new PlaybackStateChangedMessage(newState.Value));
+            }
         }
     }
 }

--- a/Narabemi/UI/Windows/MainWindow.xaml.cs
+++ b/Narabemi/UI/Windows/MainWindow.xaml.cs
@@ -12,8 +12,10 @@ using System.Windows.Media;
 using System.Windows.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.Mvvm.Messaging;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Narabemi.Messages;
 using Narabemi.Models;
 using Narabemi.Services;
 using Narabemi.UI.Controls;
@@ -35,8 +37,6 @@ namespace Narabemi.UI.Windows
 
             _viewModel = viewModel;
             _videoPlayers = MultiVideoGrid.Children.OfType<VideoPlayer>().ToArray();
-
-            mediaElementsManager.MainWindowViewModel = viewModel;
 
             controlFadeManager.AddAnimationTarget(ControlsGrid);
             controlFadeManager.AddMouseMoveTarget(MultiVideoGrid);
@@ -120,6 +120,7 @@ namespace Narabemi.UI.Windows
         private readonly VersionWindowViewModel _versionWindowViewModel;
         private readonly object _lockObj = new();
         private readonly DispatcherTimer _autoSyncTimer;
+        private bool _isUpdatingFromMedia = false;
 
         public MainWindowViewModel(
             ILogger<MainWindowViewModel> logger,
@@ -156,6 +157,13 @@ namespace Narabemi.UI.Windows
                     }
                 }
             };
+
+            WeakReferenceMessenger.Default.Register<MainWindowViewModel, PlaybackStateChangedMessage>(this, static (r, m) =>
+            {
+                r._isUpdatingFromMedia = true;
+                r.GlobalPlaybackState = m.Value;
+                r._isUpdatingFromMedia = false;
+            });
         }
 
         partial void OnMainPlayerIndexChanged(int value) =>
@@ -166,6 +174,9 @@ namespace Narabemi.UI.Windows
 
         async partial void OnGlobalPlaybackStateChanged(GlobalPlaybackState value)
         {
+            if (_isUpdatingFromMedia)
+                return;
+
             switch (value)
             {
                 case GlobalPlaybackState.Play:


### PR DESCRIPTION
## Summary

- Introduces `PlaybackStateChangedMessage` in `Narabemi/Messages/` so `MediaElementsManager` can broadcast playback state changes without referencing any ViewModel type
- Removes `MainWindowViewModel` property and `using Narabemi.UI.Windows` from `MediaElementsManager`; the service now tracks `_lastKnownPlaybackState` internally and sends the new message when media state settles
- `MainWindowViewModel` subscribes to `PlaybackStateChangedMessage` and updates `GlobalPlaybackState` with a re-entrancy guard (`_isUpdatingFromMedia`) so the update does not re-trigger the media play/pause/stop commands
- Removes the `mediaElementsManager.MainWindowViewModel = viewModel` assignment from `MainWindow.xaml.cs`

## Changes

| File | Change |
|------|--------|
| `Narabemi/Messages/PlaybackStateChangedMessage.cs` | New message type wrapping `GlobalPlaybackState` |
| `Narabemi/Services/MediaElementsManager.cs` | Remove VM property/import; publish message instead of mutating VM |
| `Narabemi/UI/Windows/MainWindow.xaml.cs` | Subscribe to message in ViewModel; add re-entrancy guard; remove VM assignment in code-behind |

## Testing

- Build: `dotnet build Narabemi/Narabemi.csproj` — succeeded, 0 errors
- The FXC shader compiler warnings are pre-existing environment issues unrelated to this change

Closes #22
