### PR TITLE
refactor: resolve VideoPlayerViewModel through DI factory instead of new

### DIFF
--- a/Narabemi/App.xaml.cs
+++ b/Narabemi/App.xaml.cs
@@ -88,7 +88,10 @@ namespace Narabemi
                         {
                             VersionText = $"{App.ProductName} v{App.Version}",
                             SiteUrl = App.SiteUrl,
-                        });
+                        })
+                        .AddTransient<UI.Controls.VideoPlayerViewModel>()
+                        .AddSingleton<Func<int, UI.Controls.VideoPlayerViewModel>>(sp =>
+                            playerId => ActivatorUtilities.CreateInstance<UI.Controls.VideoPlayerViewModel>(sp, playerId));
                 });
 
         protected override async void OnStartup(StartupEventArgs e)

--- a/Narabemi/UI/Windows/MainWindow.xaml.cs
+++ b/Narabemi/UI/Windows/MainWindow.xaml.cs
@@ -29,7 +29,7 @@ namespace Narabemi.UI.Windows
             MainWindowViewModel viewModel,
             MediaElementsManager mediaElementsManager,
             ControlFadeManager controlFadeManager,
-            ILogger<MainWindow> logger)
+            Func<int, VideoPlayerViewModel> videoPlayerViewModelFactory)
         {
             InitializeComponent();
 
@@ -48,7 +48,7 @@ namespace Narabemi.UI.Windows
 
             for (int i = 0; i < _videoPlayers.Length; i++)
             {
-                var videoPlayerVM = new VideoPlayerViewModel(logger, _viewModel, i);
+                var videoPlayerVM = videoPlayerViewModelFactory(i);
                 var videoPlayer = _videoPlayers[i];
                 videoPlayer.LateInit(videoPlayerVM);
                 _viewModel.PlayerViewModels.Add(videoPlayerVM);


### PR DESCRIPTION
## Summary

Resolves the tight coupling introduced by manually constructing `VideoPlayerViewModel` with `new` inside `MainWindow`'s constructor, bypassing the DI container.

## Changes

- **`App.xaml.cs`**: Registers `VideoPlayerViewModel` as transient and adds a `Func<int, VideoPlayerViewModel>` factory singleton using `ActivatorUtilities.CreateInstance`. The factory accepts a `playerId` at call-time while resolving `ILogger<MainWindow>` and `MainWindowViewModel` from the DI container.
- **`MainWindow.xaml.cs`**: Replaces the `ILogger<MainWindow>` constructor parameter with `Func<int, VideoPlayerViewModel> videoPlayerViewModelFactory`. The loop now calls `videoPlayerViewModelFactory(i)` instead of `new VideoPlayerViewModel(logger, _viewModel, i)`.

## Why a factory?

`VideoPlayerViewModel` requires a per-instance `playerId` (0 or 1) that is not known until construction time. A `Func<int, VideoPlayerViewModel>` factory is the idiomatic pattern with `Microsoft.Extensions.DependencyInjection` for this scenario — it keeps `VideoPlayerViewModel` fully DI-managed while passing the runtime parameter cleanly.

## Testing

- `dotnet build Narabemi/Narabemi.csproj` — build succeeds with 0 errors
- Manual test: `dotnet run --project Narabemi/Narabemi.csproj` to verify both video players initialise correctly

Closes #23
