### PR TITLE
refactor: decouple AppStatesService from MainWindowViewModel via IAppStateTarget

### DIFF
--- a/Narabemi/Settings/AppStatesService.cs
+++ b/Narabemi/Settings/AppStatesService.cs
@@ -5,7 +5,6 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using CommunityToolkit.Diagnostics;
 using Microsoft.Extensions.Logging;
-using Narabemi.UI.Windows;
 
 namespace Narabemi.Settings
 {
@@ -68,30 +67,30 @@ namespace Narabemi.Settings
             File.WriteAllText(FileName, jsonText);
         }
 
-        public void ApplyTo(MainWindowViewModel vm)
+        public void ApplyTo(IAppStateTarget target)
         {
             Guard.IsNotNull(Current);
 
-            vm.Loop = Current.Loop;
-            vm.AutoSync = Current.AutoSync;
-            vm.MainPlayerIndex = Current.MainPlayerIndex;
-            for (int i = 0; i < Math.Min(vm.PlayerViewModels.Count, Current.VideoPathList.Count); i++)
-                vm.PlayerViewModels[i].VideoPath = Current.VideoPathList[i];
-            vm.BlendBorderWidth = Current.BlendBorderWidth;
-            vm.BlendBorderColor = Current.BlendBorderColor;
+            target.Loop = Current.Loop;
+            target.AutoSync = Current.AutoSync;
+            target.MainPlayerIndex = Current.MainPlayerIndex;
+            for (int i = 0; i < Math.Min(target.StatePlayers.Count, Current.VideoPathList.Count); i++)
+                target.StatePlayers[i].VideoPath = Current.VideoPathList[i];
+            target.BlendBorderWidth = Current.BlendBorderWidth;
+            target.BlendBorderColor = Current.BlendBorderColor;
         }
 
-        public void ApplyFrom(MainWindowViewModel vm)
+        public void ApplyFrom(IAppStateTarget target)
         {
             Guard.IsNotNull(Current);
 
-            Current.Loop = vm.Loop;
-            Current.AutoSync = vm.AutoSync;
-            Current.MainPlayerIndex = vm.MainPlayerIndex;
+            Current.Loop = target.Loop;
+            Current.AutoSync = target.AutoSync;
+            Current.MainPlayerIndex = target.MainPlayerIndex;
             Current.VideoPathList.Clear();
-            Current.VideoPathList.AddRange(vm.PlayerViewModels.Select(v => v.VideoPath));
-            Current.BlendBorderWidth = vm.BlendBorderWidth;
-            Current.BlendBorderColor = vm.BlendBorderColor;
+            Current.VideoPathList.AddRange(target.StatePlayers.Select(p => p.VideoPath));
+            Current.BlendBorderWidth = target.BlendBorderWidth;
+            Current.BlendBorderColor = target.BlendBorderColor;
         }
     }
 }

--- a/Narabemi/Settings/IAppStateTarget.cs
+++ b/Narabemi/Settings/IAppStateTarget.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using System.Windows.Media;
+
+namespace Narabemi.Settings
+{
+    /// <summary>
+    /// Represents the target for reading and writing application state.
+    /// Implemented by the main view model to decouple the Settings layer from the UI layer.
+    /// </summary>
+    public interface IAppStateTarget
+    {
+        bool Loop { get; set; }
+        bool AutoSync { get; set; }
+        int MainPlayerIndex { get; set; }
+        IList<IAppStatePlayerTarget> StatePlayers { get; }
+        double BlendBorderWidth { get; set; }
+        Color BlendBorderColor { get; set; }
+    }
+
+    /// <summary>
+    /// Represents the per-player state exposed to <see cref="AppStatesService"/>.
+    /// </summary>
+    public interface IAppStatePlayerTarget
+    {
+        string VideoPath { get; set; }
+    }
+}

--- a/Narabemi/UI/Controls/VideoPlayer.xaml.cs
+++ b/Narabemi/UI/Controls/VideoPlayer.xaml.cs
@@ -15,6 +15,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Win32;
 using Narabemi.Messages;
 using Narabemi.Models;
+using Narabemi.Settings;
 using Narabemi.UI.Windows;
 using Unosquare.FFME.Common;
 
@@ -40,7 +41,7 @@ namespace Narabemi.UI.Controls
     }
 
     [INotifyPropertyChanged]
-    public partial class VideoPlayerViewModel
+    public partial class VideoPlayerViewModel : IAppStatePlayerTarget
     {
         public int PlayerId { get; }
 

--- a/Narabemi/UI/Windows/MainWindow.xaml.cs
+++ b/Narabemi/UI/Windows/MainWindow.xaml.cs
@@ -16,6 +16,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Narabemi.Models;
 using Narabemi.Services;
+using Narabemi.Settings;
 using Narabemi.UI.Controls;
 
 namespace Narabemi.UI.Windows
@@ -65,7 +66,7 @@ namespace Narabemi.UI.Windows
         private void CloseCommandBinding_CanExecute(object sender, CanExecuteRoutedEventArgs e) => e.CanExecute = true;
     }
 
-    public partial class MainWindowViewModel : ObservableValidator
+    public partial class MainWindowViewModel : ObservableValidator, IAppStateTarget
     {
         [ObservableProperty]
         private GlobalPlaybackState globalPlaybackState = GlobalPlaybackState.Init;
@@ -110,6 +111,10 @@ namespace Narabemi.UI.Windows
         public List<VideoPlayerViewModel> PlayerViewModels { get; } = new();
         public ObservableCollection<string> PlayerNames { get; } = new();
         public ObservableCollection<AspectRatio> AspectRatioPresets { get; } = new(AspectRatios.All);
+
+        // IAppStateTarget explicit implementation — exposes players through the settings-layer abstraction
+        IList<IAppStatePlayerTarget> IAppStateTarget.StatePlayers =>
+            PlayerViewModels.Cast<IAppStatePlayerTarget>().ToList();
 
         private static readonly AspectRatioToStringConverter _aspectRatioToStringConverter = new();
         private readonly ILogger<MainWindowViewModel> _logger;


### PR DESCRIPTION
## Summary

- Extracts `IAppStateTarget` and `IAppStatePlayerTarget` interfaces into `Narabemi/Settings/IAppStateTarget.cs` (within the `Narabemi.Settings` namespace)
- Changes `AppStatesService.ApplyTo` / `ApplyFrom` to accept `IAppStateTarget` instead of the concrete `MainWindowViewModel`, removing the upward `using Narabemi.UI.Windows` dependency from the Settings layer
- `MainWindowViewModel` now implements `IAppStateTarget` via an explicit `StatePlayers` property that wraps `PlayerViewModels`
- `VideoPlayerViewModel` now implements `IAppStatePlayerTarget`, satisfying the per-player contract

## Changes

| File | Change |
|------|--------|
| `Narabemi/Settings/IAppStateTarget.cs` | New — defines `IAppStateTarget` and `IAppStatePlayerTarget` |
| `Narabemi/Settings/AppStatesService.cs` | Drops `using Narabemi.UI.Windows`; `ApplyTo`/`ApplyFrom` now take `IAppStateTarget` |
| `Narabemi/UI/Windows/MainWindow.xaml.cs` | `MainWindowViewModel` implements `IAppStateTarget`; adds `StatePlayers` explicit property |
| `Narabemi/UI/Controls/VideoPlayer.xaml.cs` | `VideoPlayerViewModel` implements `IAppStatePlayerTarget` |

## Testing

- `dotnet build Narabemi/Narabemi.csproj` passes with 0 errors
- Manual testing: run the application, open two videos, close and re-open — video paths, loop, auto-sync, blend border state should persist correctly

Closes #24