### PR TITLE
refactor: extract animation logic from ControlFadeManager into UI-layer ControlFadeAnimator

### DIFF
--- a/Narabemi/Services/ControlFadeManager.cs
+++ b/Narabemi/Services/ControlFadeManager.cs
@@ -1,11 +1,10 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Timers;
 using System.Windows;
 using System.Windows.Input;
-using System.Windows.Media.Animation;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Messaging;
 using CommunityToolkit.Mvvm.Messaging.Messages;
@@ -17,13 +16,8 @@ namespace Narabemi.Services
     [INotifyPropertyChanged]
     public partial class ControlFadeManager : IDisposable, IRecipient<ControlsMouseMoveMessage>, IRecipient<ControlsVisibilityMessage>
     {
-        public Storyboard ShowControlStoryboard { get; } = new();
-        public Storyboard HideControlStoryboard { get; } = new();
         public bool IsVisible { get; private set; } = true;
 
-        private readonly Duration _durationShow = new(TimeSpan.FromMilliseconds(100));
-        private readonly Duration _durationHide = new(TimeSpan.FromMilliseconds(300));
-        private readonly PropertyPath _propPath = new("Opacity");
         private readonly TimeSpan _hideStartDuration = TimeSpan.FromMilliseconds(1000);
 
         private readonly List<FrameworkElement> _mouseMoveTargets = new();
@@ -53,18 +47,6 @@ namespace Narabemi.Services
 
         public void AddMouseHoverTarget(FrameworkElement target) =>
             _mouseHoverTargets.Add(target);
-
-        public void AddAnimationTarget(DependencyObject target)
-        {
-            var showAnim = new DoubleAnimation(0.0, 1.0, _durationShow);
-            var hideAnim = new DoubleAnimation(1.0, 0.0, _durationHide);
-            ShowControlStoryboard.Children.Add(showAnim);
-            HideControlStoryboard.Children.Add(hideAnim);
-            Storyboard.SetTargetProperty(showAnim, _propPath);
-            Storyboard.SetTargetProperty(hideAnim, _propPath);
-            Storyboard.SetTarget(showAnim, target);
-            Storyboard.SetTarget(hideAnim, target);
-        }
 
         private async void OnTimer(object? sender, ElapsedEventArgs e)
         {
@@ -112,13 +94,11 @@ namespace Narabemi.Services
                 {
                     if (newValue)
                     {
-                        ShowControlStoryboard.Begin();
                         _hideTimer.Start();
                         _mouseMoveTargets.ForEach(v => v.Cursor = Cursors.Arrow);
                     }
                     else
                     {
-                        HideControlStoryboard.Begin();
                         _mouseMoveTargets.ForEach(v => v.Cursor = Cursors.None);
                     }
 

--- a/Narabemi/UI/Controls/ControlFadeAnimator.cs
+++ b/Narabemi/UI/Controls/ControlFadeAnimator.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Windows;
+using System.Windows.Media.Animation;
+using CommunityToolkit.Mvvm.Messaging;
+using Narabemi.Services;
+
+namespace Narabemi.UI.Controls
+{
+    /// <summary>
+    /// UI-layer helper that subscribes to <see cref="ControlsVisibilityMessage"/> and drives
+    /// fade-in / fade-out animations on registered <see cref="DependencyObject"/> targets.
+    /// Keeps WPF rendering types (<see cref="Storyboard"/>, <see cref="DoubleAnimation"/>)
+    /// out of the service layer.
+    /// </summary>
+    public sealed class ControlFadeAnimator : IDisposable
+    {
+        private readonly Storyboard _showStoryboard = new();
+        private readonly Storyboard _hideStoryboard = new();
+
+        private readonly Duration _durationShow = new(TimeSpan.FromMilliseconds(100));
+        private readonly Duration _durationHide = new(TimeSpan.FromMilliseconds(300));
+        private readonly PropertyPath _propPath = new("Opacity");
+
+        public ControlFadeAnimator()
+        {
+            WeakReferenceMessenger.Default.Register<ControlsVisibilityMessage>(this, (r, m) =>
+                ((ControlFadeAnimator)r).OnVisibilityChanged(m.Value));
+        }
+
+        /// <summary>
+        /// Registers a <see cref="DependencyObject"/> to be faded in/out when
+        /// <see cref="ControlsVisibilityMessage"/> is received.
+        /// </summary>
+        public void AddTarget(DependencyObject target)
+        {
+            var showAnim = new DoubleAnimation(0.0, 1.0, _durationShow);
+            var hideAnim = new DoubleAnimation(1.0, 0.0, _durationHide);
+
+            _showStoryboard.Children.Add(showAnim);
+            _hideStoryboard.Children.Add(hideAnim);
+
+            Storyboard.SetTargetProperty(showAnim, _propPath);
+            Storyboard.SetTargetProperty(hideAnim, _propPath);
+            Storyboard.SetTarget(showAnim, target);
+            Storyboard.SetTarget(hideAnim, target);
+        }
+
+        private void OnVisibilityChanged(bool isVisible)
+        {
+            if (isVisible)
+                _showStoryboard.Begin();
+            else
+                _hideStoryboard.Begin();
+        }
+
+        public void Dispose() =>
+            WeakReferenceMessenger.Default.Unregister<ControlsVisibilityMessage>(this);
+    }
+}

--- a/Narabemi/UI/Windows/MainWindow.xaml.cs
+++ b/Narabemi/UI/Windows/MainWindow.xaml.cs
@@ -25,6 +25,8 @@ namespace Narabemi.UI.Windows
         private readonly MainWindowViewModel _viewModel;
         private readonly VideoPlayer[] _videoPlayers;
 
+        private readonly ControlFadeAnimator _controlFadeAnimator = new();
+
         public MainWindow(
             MainWindowViewModel viewModel,
             MediaElementsManager mediaElementsManager,
@@ -38,7 +40,7 @@ namespace Narabemi.UI.Windows
 
             mediaElementsManager.MainWindowViewModel = viewModel;
 
-            controlFadeManager.AddAnimationTarget(ControlsGrid);
+            _controlFadeAnimator.AddTarget(ControlsGrid);
             controlFadeManager.AddMouseMoveTarget(MultiVideoGrid);
             controlFadeManager.AddMouseMoveTarget(BlendVideoGrid);
             controlFadeManager.AddMouseHoverTarget(ControlsGrid);
@@ -56,7 +58,7 @@ namespace Narabemi.UI.Windows
 
                 mediaElementsManager.Register(i, videoPlayer.MediaElement, videoPlayerVM);
 
-                controlFadeManager.AddAnimationTarget(videoPlayer.ControlsGrid);
+                _controlFadeAnimator.AddTarget(videoPlayer.ControlsGrid);
                 controlFadeManager.AddMouseHoverTarget(videoPlayer.ControlsGrid);
             }
         }


### PR DESCRIPTION
## Summary

- Extracts `Storyboard` / `DoubleAnimation` WPF rendering types out of the `ControlFadeManager` service into a new UI-layer helper class `ControlFadeAnimator`
- `ControlFadeManager` now communicates exclusively via `ControlsVisibilityMessage` (already the messaging mechanism) — it no longer owns any WPF animation objects
- `MainWindow` creates `ControlFadeAnimator` as a field and registers animation targets on it instead

## Changes

- **`Narabemi/Services/ControlFadeManager.cs`** — removed `ShowControlStoryboard`, `HideControlStoryboard`, `AddAnimationTarget`, and all `System.Windows.Media.Animation` imports; removed `Storyboard.Begin()` calls from `Receive(ControlsVisibilityMessage)`
- **`Narabemi/UI/Controls/ControlFadeAnimator.cs`** (new) — UI-layer class that subscribes to `ControlsVisibilityMessage` via `WeakReferenceMessenger` and drives fade-in/fade-out animations on registered `DependencyObject` targets; implements `IDisposable` to unregister
- **`Narabemi/UI/Windows/MainWindow.xaml.cs`** — replaced `controlFadeManager.AddAnimationTarget(...)` calls with `_controlFadeAnimator.AddTarget(...)`

## Testing

- `dotnet build Narabemi/Narabemi.csproj` passes with 0 errors (pre-existing EOL warnings only)
- Functionality is preserved: `ControlsVisibilityMessage` is broadcast by `ControlFadeManager` as before; `ControlFadeAnimator` receives it and triggers the same storyboard animations

Closes #25
