### PR TITLE
refactor: remove dead GlobalPlaybackStateExtension.TogglePlayPause method

### DIFF
--- a/Narabemi/PlayState.cs
+++ b/Narabemi/PlayState.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Narabemi
 {
     public enum GlobalPlaybackState
@@ -8,20 +6,5 @@ namespace Narabemi
         Play,
         Pause,
         Stop,
-    }
-
-    public static class GlobalPlaybackStateExtension
-    {
-        public static GlobalPlaybackState TogglePlayPause(this GlobalPlaybackState state)
-        {
-            return state switch
-            {
-                GlobalPlaybackState.Init => GlobalPlaybackState.Play,
-                GlobalPlaybackState.Play => GlobalPlaybackState.Pause,
-                GlobalPlaybackState.Pause => GlobalPlaybackState.Play,
-                GlobalPlaybackState.Stop => GlobalPlaybackState.Play,
-                _ => throw new NotImplementedException(),
-            };
-        }
     }
 }


### PR DESCRIPTION
## Summary

- Removes the dead `GlobalPlaybackStateExtension.TogglePlayPause` extension method from `Narabemi/PlayState.cs`
- Toggling is now handled directly in `MainWindowViewModel.PlayPause` with different semantics; the extension had zero call sites
- Also drops the now-unused `using System;` import
- The `GlobalPlaybackState` enum itself is retained — it is actively used across `MainWindowViewModel` and `PlaybackStateChangedMessage`

## Verification

Confirmed zero call sites before removal:

```
grep -rn "TogglePlayPause\|GlobalPlaybackStateExtension" Narabemi/ Narabemi.Tests/
```

Only matches were the definition lines in `PlayState.cs` itself.

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — 27/27 tests pass (also ran via pre-commit hook)

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)