### PR TITLE
perf: throttle pointer-move messages in ControlFadeManager and reuse message instance

### DIFF
--- a/Narabemi/Services/ControlFadeManager.cs
+++ b/Narabemi/Services/ControlFadeManager.cs
@@ -15,13 +15,22 @@ namespace Narabemi.Services
     {
         public bool IsVisible { get; private set; } = true;
 
-        private readonly TimeSpan _hideStartDuration = TimeSpan.FromMilliseconds(1000);
+        private const long HideStartDurationMs = 1000;
+        private const long ThrottleMs = 50;
+
+        // Reused singleton — ControlsMouseMoveMessage carries no data.
+        private static readonly ControlsMouseMoveMessage _sharedMoveMessage = new();
 
         private readonly List<Control> _mouseMoveTargets = new();
         private readonly List<Control> _mouseHoverTargets = new();
         private readonly ILogger _logger;
 
-        private DateTime _lastMouseMoveTime = DateTime.UtcNow;
+        // TickCount64 (ms) of the last accepted pointer-move message sent to the messenger.
+        private long _lastSendTickCount = Environment.TickCount64;
+
+        // TickCount64 (ms) of the last received ControlsMouseMoveMessage.
+        private long _lastMouseMoveTick = Environment.TickCount64;
+
         private readonly DispatcherTimer _hideTimer;
 
         public ControlFadeManager(ILogger<ControlFadeManager> logger)
@@ -36,7 +45,16 @@ namespace Narabemi.Services
 
         public void AddMouseMoveTarget(Control target)
         {
-            target.PointerMoved += (_, _) => WeakReferenceMessenger.Default.Send(new ControlsMouseMoveMessage());
+            target.PointerMoved += (_, _) =>
+            {
+                // Throttle: only forward pointer-move messages at most once per ThrottleMs.
+                var now = Environment.TickCount64;
+                if (now - _lastSendTickCount < ThrottleMs)
+                    return;
+
+                _lastSendTickCount = now;
+                WeakReferenceMessenger.Default.Send(_sharedMoveMessage);
+            };
             _mouseMoveTargets.Add(target);
         }
 
@@ -47,8 +65,8 @@ namespace Narabemi.Services
         {
             if (IsVisible)
             {
-                var elapsed = DateTime.UtcNow - _lastMouseMoveTime;
-                if (elapsed > _hideStartDuration)
+                var elapsedMs = Environment.TickCount64 - _lastMouseMoveTick;
+                if (elapsedMs > HideStartDurationMs)
                 {
                     if (!_mouseHoverTargets.Any(v => v.IsPointerOver))
                         WeakReferenceMessenger.Default.Send(new ControlsVisibilityMessage(false));
@@ -62,7 +80,7 @@ namespace Narabemi.Services
 
         public void Receive(ControlsMouseMoveMessage message)
         {
-            _lastMouseMoveTime = DateTime.UtcNow;
+            _lastMouseMoveTick = Environment.TickCount64;
             if (!IsVisible)
                 WeakReferenceMessenger.Default.Send(new ControlsVisibilityMessage(true));
         }


### PR DESCRIPTION
## Summary

- Throttle `PointerMoved` sends to at most once per 50 ms — raw mouse-poll rate is ~125 Hz (8 ms), so this still provides smooth fade-in/out behavior while cutting message volume by ~6x under normal use.
- Reuse a single static `ControlsMouseMoveMessage` instance across all sends; since the type carries no payload, sharing is safe and eliminates per-move heap allocation.
- Replace `DateTime.UtcNow` / `TimeSpan` arithmetic in `Receive` and `OnTimer` with `Environment.TickCount64` (`long` subtraction) — cheaper, allocation-free, and monotonic.
- Convert `_hideStartDuration TimeSpan` field to `const long HideStartDurationMs` to match the new integer-tick arithmetic.

## Changes

- `Narabemi/Services/ControlFadeManager.cs` — all changes confined to the pointer-move send path and the receive/timer timestamp tracking. The cursor-allocation site (line 85) is intentionally untouched (reserved for #101).

## Testing

- `dotnet build` — 0 warnings, 0 errors.
- `dotnet test` — 27/27 passed (pre-commit hook confirmed).

Closes #104