### PR TITLE
docs: document --set-ratio/--set-mode/--verify-wipe CLI flags and exit codes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,28 @@ MainWindow (Grid: rows = "*,Auto")
 
 All test modes skip `appstates.json` write on exit so they don't clobber user state.
 
+### Snapshot mode additional flags
+
+These flags apply only when `--snapshot` is active.
+
+| Flag | Type | Default | Purpose |
+|---|---|---|---|
+| `--set-ratio <0..1>` | `double` | (uses saved `BlendRatio`) | Overrides `BlendRatio` before the run, allowing CI to pin an exact wipe position without editing saved state. |
+| `--set-mode <horizontal\|vertical\|h\|v\|0\|1>` | string | (uses saved `BlendMode`) | Overrides `BlendMode` before the run. `0`/`h`/`horizontal` = side-by-side; `1`/`v`/`vertical` = stacked. |
+| `--verify-wipe` | flag | off | After dual-player capture succeeds, runs a pixel-diff across the wipe seam (A's last cropped column vs B's first). A large diff signals a mis-stitched wipe. Intended for autonomous CI regression tests. |
+
+### Snapshot exit codes
+
+`SnapshotRunner.Shutdown` passes one of the following codes to the process exit:
+
+| Code | Meaning |
+|---|---|
+| 0 | Success (and `--verify-wipe` passed, if requested). |
+| 1 | Unhandled exception during capture. |
+| 2 | Timeout — video did not load or settle within 30 s. |
+| 3 | Crop-dimension verification failed after 5 attempts (captured frame dimensions do not match expected crop). |
+| 4 | `--verify-wipe` seam-diff check failed (wipe appears mis-stitched). |
+
 ## Code Style
 
 - Warnings treated as errors in Debug and Release.

--- a/README.md
+++ b/README.md
@@ -71,10 +71,33 @@ dotnet run --project Narabemi/Narabemi.csproj -- --bench 15 \
 dotnet run --project Narabemi/Narabemi.csproj -- --snapshot --seek 5 \
     --video-a A.mp4 --video-b B.mp4 -o snapshot.png
 
+# Snapshot with a pinned wipe position and seam verification (for CI)
+dotnet run --project Narabemi/Narabemi.csproj -- --snapshot --seek 5 \
+    --video-a A.mp4 --video-b B.mp4 -o snapshot.png \
+    --set-ratio 0.5 --set-mode horizontal --verify-wipe
+
 # Architectural probe (skips the main UI, useful for raw rendering experiments)
 dotnet run --project Narabemi/Narabemi.csproj -- --probe-native 15 \
     --video-a A.mp4 [--video-b B.mp4]
 ```
+
+### Snapshot flags
+
+| Flag | Purpose |
+|---|---|
+| `--set-ratio <0..1>` | Override the wipe position (BlendRatio) for this run. |
+| `--set-mode <horizontal\|vertical\|h\|v\|0\|1>` | Override the split direction (BlendMode) for this run. |
+| `--verify-wipe` | After capture, diff the pixel columns at the wipe seam and exit with code 4 if the seam is mis-stitched. Intended for CI regression checks. |
+
+### Snapshot exit codes
+
+| Code | Meaning |
+|---|---|
+| 0 | Success. |
+| 1 | Unhandled exception during capture. |
+| 2 | Timeout (video did not load or settle within 30 s). |
+| 3 | Captured frame dimensions do not match expected crop after 5 attempts. |
+| 4 | `--verify-wipe` seam-diff check failed. |
 
 ## Limitations
 


### PR DESCRIPTION
## Summary

- Add `--set-ratio`, `--set-mode`, and `--verify-wipe` flag documentation to both `CLAUDE.md` and `README.md`.
- Add snapshot exit code tables (codes 0–4) to both files, derived from `SnapshotRunner.Shutdown`.
- Add a CI-oriented example command showing all three new flags together.

## Changes

**`CLAUDE.md`** — New subsections under "Test Modes":
- "Snapshot mode additional flags" — table with flag name, type, default, and purpose for each of the three new flags.
- "Snapshot exit codes" — table mapping exit codes 0–4 to their meanings (sourced from `SnapshotRunner.cs`).

**`README.md`** — Extended "Test / benchmark modes" section:
- Added a CI example command using `--set-ratio 0.5 --set-mode horizontal --verify-wipe`.
- "Snapshot flags" table (name + purpose).
- "Snapshot exit codes" table (matching `CLAUDE.md`).

Conflict notes: new content is in isolated subsections at `CLAUDE.md:83–103`, well below the `Messages/` paragraph (#92 scope) and the `BlendBorder` lines (#105 scope).

## Testing

- `dotnet build` — 0 warnings, 0 errors.
- `dotnet test` — 27/27 passed (including pre-commit hook run).
- Documentation-only change; no runtime behavior altered.

Closes #106
