### PR TITLE
fix: resolve appstates.json against install directory instead of CWD

### DIFF
--- a/Narabemi.Tests/AppStatesServiceTests.cs
+++ b/Narabemi.Tests/AppStatesServiceTests.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.IO;
 using Microsoft.Extensions.Logging.Abstractions;
 using Narabemi.Settings;
 using Xunit;
@@ -28,6 +30,16 @@ namespace Narabemi.Tests
             public ColorRgba BlendBorderColor { get; set; }
             public double BlendRatio { get; set; }
             public int BlendMode { get; set; }
+        }
+
+        [Fact]
+        public void FilePath_IsRelativeToInstallDirectory()
+        {
+            // AppStatesService.FilePath must be anchored to AppContext.BaseDirectory, not CWD.
+            // This ensures the file is always found/written next to the EXE regardless of the
+            // working directory from which the process was launched.
+            var expected = Path.Combine(AppContext.BaseDirectory, "appstates.json");
+            Assert.Equal(expected, AppStatesService.FilePath, StringComparer.OrdinalIgnoreCase);
         }
 
         [Fact]

--- a/Narabemi/AssemblyInfo.cs
+++ b/Narabemi/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Narabemi.Tests")]

--- a/Narabemi/Settings/AppStatesService.cs
+++ b/Narabemi/Settings/AppStatesService.cs
@@ -13,7 +13,9 @@ namespace Narabemi.Settings
     /// </summary>
     public class AppStatesService
     {
-        private const string FileName = "appstates.json";
+        // Internal for unit-testing: lets tests assert that the path is install-relative.
+        internal static readonly string FilePath =
+            Path.Combine(AppContext.BaseDirectory, "appstates.json");
 
         private readonly JsonSerializerOptions _opt = new()
         {
@@ -34,27 +36,27 @@ namespace Narabemi.Settings
 
         public void LoadFile()
         {
-            if (!File.Exists(FileName))
+            if (!File.Exists(FilePath))
             {
-                _logger.LogWarning("{FileName} not found; using default {TypeName}.", FileName, nameof(AppStates));
+                _logger.LogWarning("{FilePath} not found; using default {TypeName}.", FilePath, nameof(AppStates));
                 Current = new AppStates();
                 return;
             }
 
             try
             {
-                var jsonText = File.ReadAllText(FileName);
+                var jsonText = File.ReadAllText(FilePath);
                 Current = JsonSerializer.Deserialize<AppStates>(jsonText, _opt);
 
                 if (Current is null)
                 {
-                    _logger.LogWarning("{FileName} deserialized to null; using default {TypeName}.", FileName, nameof(AppStates));
+                    _logger.LogWarning("{FilePath} deserialized to null; using default {TypeName}.", FilePath, nameof(AppStates));
                     Current = new AppStates();
                 }
             }
             catch (Exception ex) when (ex is IOException or JsonException)
             {
-                _logger.LogWarning(ex, "Failed to load {FileName}; using default {TypeName}.", FileName, nameof(AppStates));
+                _logger.LogWarning(ex, "Failed to load {FilePath}; using default {TypeName}.", FilePath, nameof(AppStates));
                 Current = new AppStates();
             }
         }
@@ -64,7 +66,7 @@ namespace Narabemi.Settings
             Guard.IsNotNull(Current);
 
             var jsonText = JsonSerializer.Serialize(Current, _opt);
-            File.WriteAllText(FileName, jsonText);
+            File.WriteAllText(FilePath, jsonText);
         }
 
         public void ApplyTo(IAppStateTarget target)


### PR DESCRIPTION
## Summary

- `AppStatesService` was using a bare relative path `"appstates.json"`, so reads and writes resolved against the process working directory rather than the EXE install folder.
- Launching via a shortcut whose "Start in" differs from the EXE directory, or running `cd C:\ && Narabemi.exe`, caused a fresh default state each session and a stray `appstates.json` written to CWD (silent state loss).
- Fix combines the filename with `AppContext.BaseDirectory`, consistent with how `Program.cs` and `App.axaml.cs` locate all other install-relative resources.

## Changes

- `Narabemi/Settings/AppStatesService.cs` — replace `private const string FileName` bare path with `internal static readonly string FilePath` anchored to `AppContext.BaseDirectory`; update all four call sites (`File.Exists`, `File.ReadAllText` ×2, `File.WriteAllText`) and their log-parameter names.
- `Narabemi/AssemblyInfo.cs` — add `[assembly: InternalsVisibleTo("Narabemi.Tests")]` so the test project can access `FilePath`.
- `Narabemi.Tests/AppStatesServiceTests.cs` — add `FilePath_IsRelativeToInstallDirectory` test that asserts the resolved path equals `Path.Combine(AppContext.BaseDirectory, "appstates.json")`.

## Testing

- `dotnet test Narabemi.Tests/Narabemi.Tests.csproj` — 2 tests pass (existing round-trip test + new path test).
- Release build clean (no errors, no new warnings).

Closes #107