### PR TITLE
fix: improve drop overlay with visible background and text hint

### DIFF
--- a/Narabemi/Views/MainWindow.axaml
+++ b/Narabemi/Views/MainWindow.axaml
@@ -51,12 +51,24 @@
                 <controls:VideoPlayerControl x:Name="PlayerBView"
                                              DataContext="{Binding PlayerB}" />
             </Grid>
-            <!-- Drop feedback overlay: non-interactive, shows a blue border on DragEnter.
-                 Declared last so it renders on top of InnerVideoGrid. -->
-            <Border x:Name="DropBorder"
+            <!-- Drop feedback overlay: non-interactive, shown on DragEnter with a
+                 semi-transparent tinted background and drop-hint text so users know
+                 where the file will land. Declared last so it renders on top of
+                 InnerVideoGrid. IsVisible is toggled in code-behind. -->
+            <Border x:Name="DropOverlay"
+                    Background="#AA001833"
                     BorderBrush="#4488FF"
-                    BorderThickness="0"
-                    IsHitTestVisible="False" />
+                    BorderThickness="4"
+                    IsHitTestVisible="False"
+                    IsVisible="False">
+                <TextBlock HorizontalAlignment="Center"
+                           VerticalAlignment="Center"
+                           TextAlignment="Center"
+                           FontSize="20"
+                           FontWeight="SemiBold"
+                           Foreground="White"
+                           Text="Drop video here&#10;Left half → Player A  |  Right half → Player B" />
+            </Border>
         </Grid>
 
         <!-- Control panel -->

--- a/Narabemi/Views/MainWindow.axaml.cs
+++ b/Narabemi/Views/MainWindow.axaml.cs
@@ -500,7 +500,7 @@ namespace Narabemi.Views
         {
             if (e.Data.Contains(DataFormats.Files))
             {
-                DropBorder.BorderThickness = new Thickness(3);
+                DropOverlay.IsVisible = true;
                 e.DragEffects = DragDropEffects.Copy;
             }
             else
@@ -511,12 +511,12 @@ namespace Narabemi.Views
 
         private void OnDragLeave(object? sender, DragEventArgs e)
         {
-            DropBorder.BorderThickness = new Thickness(0);
+            DropOverlay.IsVisible = false;
         }
 
         private void OnDrop(object? sender, DragEventArgs e)
         {
-            DropBorder.BorderThickness = new Thickness(0);
+            DropOverlay.IsVisible = false;
 
             if (DataContext is not MainWindowViewModel vm)
                 return;


### PR DESCRIPTION
## Summary

- Replace the barely-visible 3 px blue `DropBorder` (transparent fill, near-invisible stroke) with a named `DropOverlay` that shows a semi-transparent dark tint (`#AA001833`) and a 4 px `#4488FF` border on DragEnter.
- Add a centred `TextBlock` inside the overlay that reads "Drop video here / Left half → Player A  |  Right half → Player B", giving first-time users clear feedback about where a dropped file will land.
- `IsVisible` is toggled in code-behind (`OnDragEnter` / `OnDragLeave` / `OnDrop`); the overlay is fully non-interactive (`IsHitTestVisible="False"`).
- Changes are strictly scoped to the overlay XAML element and the three drag event handlers — no other areas of `MainWindow.axaml.cs` are touched.

## Test plan

- [ ] Build passes with 0 warnings (`dotnet build Narabemi/Narabemi.csproj`)
- [ ] All 27 unit tests pass (`dotnet test Narabemi.Tests/Narabemi.Tests.csproj`)
- [ ] Drag a video file over the window: overlay appears with tinted background, border, and hint text
- [ ] Release the drag outside the window: overlay disappears cleanly
- [ ] Drop a single file on the left half: Player A loads it
- [ ] Drop a single file on the right half: Player B loads it
- [ ] Drop two files at once: Player A and Player B each get one

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)