### PR TITLE
fix: catch and log StorageProvider exceptions in OpenFileAsync

### DIFF
--- a/Narabemi/Views/MainWindow.axaml.cs
+++ b/Narabemi/Views/MainWindow.axaml.cs
@@ -12,6 +12,8 @@ using Avalonia.Platform.Storage;
 using Narabemi.Services;
 using Narabemi.Settings;
 using Narabemi.UI.Controls;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Narabemi.ViewModels;
 
 namespace Narabemi.Views
@@ -46,8 +48,15 @@ namespace Narabemi.Views
         private ControlFadeAnimator? _fadeAnimator;
         private ControlFadeManager? _fadeManager;
 
-        public MainWindow()
+        private readonly ILogger<MainWindow> _logger;
+
+        // Parameterless ctor kept for the Avalonia designer; chains to the logger ctor
+        // so InitializeComponent() is always called exactly once.
+        public MainWindow() : this(NullLogger<MainWindow>.Instance) { }
+
+        public MainWindow(ILogger<MainWindow> logger)
         {
+            _logger = logger;
             InitializeComponent();
         }
 
@@ -435,12 +444,14 @@ namespace Narabemi.Views
                     e.Handled = true;
                     break;
                 case Key.O when ctrl && !shift:
-                    // Ctrl+O → open file for primary player
+                    // Ctrl+O → open file for primary player. Fire-and-forget is safe:
+                    // OpenFileAsync catches all exceptions internally and logs them.
                     _ = OpenFileAsync(vm.PrimaryPlayer);
                     e.Handled = true;
                     break;
                 case Key.O when ctrl && shift:
-                    // Ctrl+Shift+O → open file for secondary player
+                    // Ctrl+Shift+O → open file for secondary player. Fire-and-forget is safe:
+                    // OpenFileAsync catches all exceptions internally and logs them.
                     var secondary = vm.MainPlayerIndex == 0 ? vm.PlayerB : vm.PlayerA;
                     _ = OpenFileAsync(secondary);
                     e.Handled = true;
@@ -450,29 +461,35 @@ namespace Narabemi.Views
 
         private async System.Threading.Tasks.Task OpenFileAsync(VideoPlayerViewModel target)
         {
-            var files = await StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+            try
             {
-                Title = "Open video file",
-                AllowMultiple = false,
-                FileTypeFilter = new[]
+                var files = await StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
                 {
-                    new FilePickerFileType("Video files")
+                    Title = "Open video file",
+                    AllowMultiple = false,
+                    FileTypeFilter = new[]
                     {
-                        Patterns = new[] { "*.mp4", "*.mkv", "*.avi", "*.mov", "*.wmv",
-                                           "*.flv", "*.webm", "*.m4v", "*.ts", "*.mts" },
+                        new FilePickerFileType("Video files")
+                        {
+                            Patterns = new[] { "*.mp4", "*.mkv", "*.avi", "*.mov", "*.wmv",
+                                               "*.flv", "*.webm", "*.m4v", "*.ts", "*.mts" },
+                        },
+                        new FilePickerFileType("All files") { Patterns = new[] { "*.*" } },
                     },
-                    new FilePickerFileType("All files") { Patterns = new[] { "*.*" } },
-                },
-            });
+                });
 
-            if (files.Count > 0)
+                if (files.Count > 0)
+                {
+                    var path = files[0].TryGetLocalPath();
+                    if (path is not null)
+                        target.VideoPath = path;
+                }
+            }
+            catch (Exception ex)
             {
-                var path = files[0].TryGetLocalPath();
-                if (path is not null)
-                    target.VideoPath = path;
+                _logger.LogError(ex, "File picker failed");
             }
         }
-
         private void OnBlendModeButtonClick(object? sender, RoutedEventArgs e)
         {
             if (DataContext is MainWindowViewModel vm)


### PR DESCRIPTION
## Summary

- `OpenFileAsync` in `MainWindow` was called fire-and-forget (`_ = OpenFileAsync(...)`) with no exception handling. Any `StorageProvider.OpenFilePickerAsync` failure (COM error, OS policy block, transient I/O) would silently become an unobserved task exception with no user feedback or diagnostic trail.
- Added `ILogger<MainWindow>` injected via constructor (DI selects the greedy ctor; parameterless ctor chains to it using `NullLogger<MainWindow>.Instance` for designer compat).
- Wrapped the `OpenFilePickerAsync` call in `try/catch (Exception ex)` and logs via `_logger.LogError(ex, "File picker failed")`.
- The fire-and-forget discard (`_ =`) is now safe because `OpenFileAsync` can never produce a faulted task — all exceptions are caught internally. Added clarifying comments at both call sites.

## Changes

- `Narabemi/Views/MainWindow.axaml.cs`:
  - Add `using Microsoft.Extensions.Logging;` and `using Microsoft.Extensions.Logging.Abstractions;`
  - Add `private readonly ILogger<MainWindow> _logger;` field
  - Replace parameterless constructor with chained pair: `MainWindow()` → `MainWindow(ILogger<MainWindow> logger)`
  - Wrap `OpenFilePickerAsync` in `try/catch` with `_logger.LogError`
  - Add explanatory comments at both `_ = OpenFileAsync(...)` call sites

## Testing

- `dotnet build` — 0 warnings, 0 errors
- `dotnet test` — 27/27 passed

For manual verification:
```
dotnet run --project Narabemi/Narabemi.csproj
```
Press `Ctrl+O` or `Ctrl+Shift+O` to open a file — check `Narabemi.log` for error entries if a failure occurs.

Closes #90
