### PR TITLE
feat: add global unhandled exception handler and crash reporting

### DIFF
--- a/Narabemi/App.axaml.cs
+++ b/Narabemi/App.axaml.cs
@@ -1,11 +1,13 @@
 using System;
 using System.IO;
 using System.Reflection;
+using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Data.Core;
 using Avalonia.Data.Core.Plugins;
 using Avalonia.Markup.Xaml;
+using Avalonia.Threading;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -41,96 +43,177 @@ namespace Narabemi
 
         public override void OnFrameworkInitializationCompleted()
         {
+            // Subscribe to all three global exception streams before any startup work
+            // so that crashes during DI build, mpv init, or view-model construction
+            // are captured rather than silently terminating the process.
+            RegisterGlobalExceptionHandlers();
+
             if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
             {
-                DisableAvaloniaDataAnnotationValidation();
-
-                var snapshotArgs = SnapshotArgs.Parse(desktop.Args);
-
-                _host = CreateHostBuilder().Build();
-                Services = _host.Services;
-
-                if (snapshotArgs.IsProbeNativeMode)
+                try
                 {
-                    var probeLogger = Services.GetRequiredService<ILogger<ProbeRunner>>();
-                    new ProbeRunner(snapshotArgs, probeLogger).Start();
-                    base.OnFrameworkInitializationCompleted();
+                    InitializeDesktop(desktop);
+                }
+                catch (Exception ex)
+                {
+                    // Startup failure (missing libmpv, corrupt appstates.json, DI resolution
+                    // error, etc.) — log, write crash file, and show a dialog before exit.
+                    var logger = TryGetLogger<App>();
+                    CrashHandler.Handle(ex, logger, "startup");
+                    FlushAndShutdownHost();
+                    Environment.Exit(1);
                     return;
-                }
-
-                var appStatesService = Services.GetRequiredService<AppStatesService>();
-                appStatesService.LoadFile();
-
-                // In snapshot/bench mode, override video paths before ApplyTo runs
-                if (snapshotArgs.IsSnapshotMode || snapshotArgs.IsBenchMode)
-                {
-                    var state = appStatesService.Current!;
-                    if (snapshotArgs.VideoPathA is not null)
-                    {
-                        state.VideoPathList.Clear();
-                        state.VideoPathList.Add(snapshotArgs.VideoPathA);
-                        if (snapshotArgs.VideoPathB is not null)
-                            state.VideoPathList.Add(snapshotArgs.VideoPathB);
-                    }
-                }
-
-                var mainWindow = Services.GetRequiredService<MainWindow>();
-                var mainVm = Services.GetRequiredService<MainWindowViewModel>();
-                var fadeManager = Services.GetRequiredService<ControlFadeManager>();
-
-                mainWindow.DataContext = mainVm;
-                // Skip window geometry restore in headless test modes so the fixed
-                // 1280×720 XAML default is used for reproducible snapshot/bench output.
-                var savedState = (snapshotArgs.IsSnapshotMode || snapshotArgs.IsBenchMode)
-                    ? null : appStatesService.Current;
-                mainWindow.Initialize(fadeManager, savedState);
-                if (snapshotArgs.IsSnapshotMode || snapshotArgs.IsBenchMode)
-                    mainVm.IsSnapshotMode = true;
-                if (snapshotArgs.IsBenchMode)
-                    mainVm.IsBenchMode = true;
-
-                // CLI overrides for layout — applied AFTER appstates restore so they win.
-                // The state restore happens via vm.LoadedCommand which fires on Window.Loaded;
-                // hook to re-apply overrides right after that.
-                if (snapshotArgs.SetRatio.HasValue || snapshotArgs.SetMode.HasValue)
-                {
-                    void ApplyOverrides(object? _, Avalonia.Interactivity.RoutedEventArgs __)
-                    {
-                        if (snapshotArgs.SetMode.HasValue)  mainVm.BlendMode  = snapshotArgs.SetMode.Value;
-                        if (snapshotArgs.SetRatio.HasValue) mainVm.BlendRatio = snapshotArgs.SetRatio.Value;
-                        mainWindow.Loaded -= ApplyOverrides;
-                    }
-                    mainWindow.Loaded += ApplyOverrides;
-                }
-
-                desktop.MainWindow = mainWindow;
-
-                // Don't save appstates on exit in snapshot/bench mode (avoids overwriting user state)
-                if (!snapshotArgs.IsSnapshotMode && !snapshotArgs.IsBenchMode)
-                {
-                    desktop.ShutdownRequested += (_, _) =>
-                    {
-                        appStatesService.ApplyFrom(mainVm);
-                        appStatesService.SaveFile();
-                    };
-                }
-
-                // Start snapshot/bench runner after window is shown
-                if (snapshotArgs.IsSnapshotMode)
-                {
-                    var logger = Services.GetRequiredService<ILogger<SnapshotRunner>>();
-                    var runner = new SnapshotRunner(snapshotArgs, mainVm, logger);
-                    runner.Start(mainWindow);
-                }
-                else if (snapshotArgs.IsBenchMode)
-                {
-                    var logger = Services.GetRequiredService<ILogger<BenchmarkRunner>>();
-                    var runner = new BenchmarkRunner(snapshotArgs, mainVm, logger);
-                    runner.Start();
                 }
             }
 
             base.OnFrameworkInitializationCompleted();
+        }
+
+        private void RegisterGlobalExceptionHandlers()
+        {
+            // CLR thread-pool and background threads.
+            AppDomain.CurrentDomain.UnhandledException += (_, args) =>
+            {
+                var ex = args.ExceptionObject as Exception
+                    ?? new Exception(args.ExceptionObject?.ToString() ?? "Unknown error");
+                var logger = TryGetLogger<App>();
+                CrashHandler.Handle(ex, logger, "AppDomain.UnhandledException");
+                FlushAndShutdownHost();
+                // IsTerminating is already true when this fires; let CLR exit.
+            };
+
+            // Fire-and-forget async tasks that faulted without an awaiter.
+            TaskScheduler.UnobservedTaskException += (_, args) =>
+            {
+                args.SetObserved();   // prevent CLR from re-throwing on GC finaliser thread
+                var logger = TryGetLogger<App>();
+                CrashHandler.Handle(args.Exception, logger, "TaskScheduler.UnobservedTaskException");
+            };
+
+            // Avalonia dispatcher (UI thread).
+            Dispatcher.UIThread.UnhandledException += (_, args) =>
+            {
+                args.Handled = true;  // prevent Avalonia from re-throwing / crashing
+                var logger = TryGetLogger<App>();
+                CrashHandler.Handle(args.Exception, logger, "Dispatcher.UIThread.UnhandledException");
+                FlushAndShutdownHost();
+                Environment.Exit(1);
+            };
+        }
+
+        private void InitializeDesktop(IClassicDesktopStyleApplicationLifetime desktop)
+        {
+            DisableAvaloniaDataAnnotationValidation();
+
+            var snapshotArgs = SnapshotArgs.Parse(desktop.Args);
+
+            _host = CreateHostBuilder().Build();
+            Services = _host.Services;
+
+            if (snapshotArgs.IsProbeNativeMode)
+            {
+                var probeLogger = Services.GetRequiredService<ILogger<ProbeRunner>>();
+                new ProbeRunner(snapshotArgs, probeLogger).Start();
+                base.OnFrameworkInitializationCompleted();
+                return;
+            }
+
+            var appStatesService = Services.GetRequiredService<AppStatesService>();
+            appStatesService.LoadFile();
+
+            // In snapshot/bench mode, override video paths before ApplyTo runs
+            if (snapshotArgs.IsSnapshotMode || snapshotArgs.IsBenchMode)
+            {
+                var state = appStatesService.Current!;
+                if (snapshotArgs.VideoPathA is not null)
+                {
+                    state.VideoPathList.Clear();
+                    state.VideoPathList.Add(snapshotArgs.VideoPathA);
+                    if (snapshotArgs.VideoPathB is not null)
+                        state.VideoPathList.Add(snapshotArgs.VideoPathB);
+                }
+            }
+
+            var mainWindow = Services.GetRequiredService<MainWindow>();
+            var mainVm = Services.GetRequiredService<MainWindowViewModel>();
+            var fadeManager = Services.GetRequiredService<ControlFadeManager>();
+
+            mainWindow.DataContext = mainVm;
+            // Skip window geometry restore in headless test modes so the fixed
+            // 1280×720 XAML default is used for reproducible snapshot/bench output.
+            var savedState = (snapshotArgs.IsSnapshotMode || snapshotArgs.IsBenchMode)
+                ? null : appStatesService.Current;
+            mainWindow.Initialize(fadeManager, savedState);
+            if (snapshotArgs.IsSnapshotMode || snapshotArgs.IsBenchMode)
+                mainVm.IsSnapshotMode = true;
+            if (snapshotArgs.IsBenchMode)
+                mainVm.IsBenchMode = true;
+
+            // CLI overrides for layout — applied AFTER appstates restore so they win.
+            // The state restore happens via vm.LoadedCommand which fires on Window.Loaded;
+            // hook to re-apply overrides right after that.
+            if (snapshotArgs.SetRatio.HasValue || snapshotArgs.SetMode.HasValue)
+            {
+                void ApplyOverrides(object? _, Avalonia.Interactivity.RoutedEventArgs __)
+                {
+                    if (snapshotArgs.SetMode.HasValue)  mainVm.BlendMode  = snapshotArgs.SetMode.Value;
+                    if (snapshotArgs.SetRatio.HasValue) mainVm.BlendRatio = snapshotArgs.SetRatio.Value;
+                    mainWindow.Loaded -= ApplyOverrides;
+                }
+                mainWindow.Loaded += ApplyOverrides;
+            }
+
+            desktop.MainWindow = mainWindow;
+
+            // Don't save appstates on exit in snapshot/bench mode (avoids overwriting user state)
+            if (!snapshotArgs.IsSnapshotMode && !snapshotArgs.IsBenchMode)
+            {
+                desktop.ShutdownRequested += (_, _) =>
+                {
+                    appStatesService.ApplyFrom(mainVm);
+                    appStatesService.SaveFile();
+                };
+            }
+
+            // Start snapshot/bench runner after window is shown
+            if (snapshotArgs.IsSnapshotMode)
+            {
+                var logger = Services.GetRequiredService<ILogger<SnapshotRunner>>();
+                var runner = new SnapshotRunner(snapshotArgs, mainVm, logger);
+                runner.Start(mainWindow);
+            }
+            else if (snapshotArgs.IsBenchMode)
+            {
+                var logger = Services.GetRequiredService<ILogger<BenchmarkRunner>>();
+                var runner = new BenchmarkRunner(snapshotArgs, mainVm, logger);
+                runner.Start();
+            }
+        }
+
+        /// <summary>
+        /// Attempts to obtain an <see cref="ILogger{T}"/> from the DI container.
+        /// Returns <c>null</c> if the host has not been built yet or has already
+        /// been disposed.
+        /// </summary>
+        private ILogger<T>? TryGetLogger<T>()
+        {
+            try { return _host?.Services.GetService<ILogger<T>>(); }
+            catch { return null; }
+        }
+
+        /// <summary>
+        /// Stops the hosted service (which triggers ZLogger flush) without throwing.
+        /// </summary>
+        private void FlushAndShutdownHost()
+        {
+            try
+            {
+                _host?.StopAsync(TimeSpan.FromSeconds(5)).GetAwaiter().GetResult();
+            }
+            catch
+            {
+                // Swallow — we are already in an error path.
+            }
         }
 
         private static IHostBuilder CreateHostBuilder() =>

--- a/Narabemi/Services/CrashHandler.cs
+++ b/Narabemi/Services/CrashHandler.cs
@@ -1,0 +1,129 @@
+using System;
+using System.IO;
+using System.Threading;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Avalonia.Threading;
+using Microsoft.Extensions.Logging;
+
+namespace Narabemi.Services
+{
+    /// <summary>
+    /// Handles unhandled exceptions by writing a crash log and showing a minimal
+    /// error dialog. Called from the three global exception hooks in App.
+    /// </summary>
+    internal static class CrashHandler
+    {
+        /// <summary>
+        /// Writes a crash log file to AppContext.BaseDirectory and, if called on or
+        /// dispatched to the UI thread, shows a blocking error dialog before returning.
+        /// Safe to call from background threads and from within exception handlers.
+        /// </summary>
+        internal static void Handle(Exception ex, ILogger? logger, string context)
+        {
+            // 1. Log via structured logger (best-effort — logger may not be built yet).
+            try
+            {
+                logger?.LogCritical(ex, "Unhandled exception [{Context}]", context);
+            }
+            catch
+            {
+                // Swallow — logger itself might be broken.
+            }
+
+            // 2. Write a plain-text crash log alongside the executable.
+            try
+            {
+                var logPath = Path.Combine(AppContext.BaseDirectory, "crash.log");
+                File.WriteAllText(logPath,
+                    $"{DateTime.Now:u}  [{context}]\n{ex}\n");
+            }
+            catch
+            {
+                // Swallow — disk might be full or path inaccessible.
+            }
+
+            // 3. Show a minimal error dialog on the UI thread.
+            try
+            {
+                ShowErrorDialog(ex, context);
+            }
+            catch
+            {
+                // Swallow — UI may already be torn down.
+            }
+        }
+
+        private static void ShowErrorDialog(Exception ex, string context)
+        {
+            // Build a self-contained error window that doesn't depend on the DI container
+            // or XAML resources so it works even when those failed to initialise.
+            void Show()
+            {
+                var message = $"An unexpected error occurred ({context}).\n\n" +
+                              $"A crash log has been written to:\n  crash.log\n\n" +
+                              $"{ex.GetType().Name}: {ex.Message}";
+
+                var textBlock = new TextBlock
+                {
+                    Text = message,
+                    TextWrapping = TextWrapping.Wrap,
+                    Margin = new Thickness(16),
+                    MaxWidth = 560,
+                };
+
+                var button = new Button
+                {
+                    Content = "Close",
+                    HorizontalAlignment = HorizontalAlignment.Right,
+                    Margin = new Thickness(16, 0, 16, 16),
+                };
+
+                var panel = new StackPanel();
+                panel.Children.Add(textBlock);
+                panel.Children.Add(button);
+
+                var owner = (Application.Current?.ApplicationLifetime
+                    as IClassicDesktopStyleApplicationLifetime)?.MainWindow;
+
+                var dialog = new Window
+                {
+                    Title = $"{App.ProductName} — Unhandled Error",
+                    Content = panel,
+                    Width = 600,
+                    SizeToContent = SizeToContent.Height,
+                    WindowStartupLocation = owner is not null
+                        ? WindowStartupLocation.CenterOwner
+                        : WindowStartupLocation.CenterScreen,
+                };
+
+                button.Click += (_, _) => dialog.Close();
+
+                if (owner is not null)
+                    dialog.ShowDialog(owner).GetAwaiter().GetResult();
+                else
+                    dialog.Show();
+            }
+
+            if (Dispatcher.UIThread.CheckAccess())
+            {
+                Show();
+            }
+            else
+            {
+                // Block the calling thread until the dialog is closed so the process
+                // doesn't exit before the user has seen the message.
+                using var done = new ManualResetEventSlim(false);
+                Dispatcher.UIThread.Post(() =>
+                {
+                    try { Show(); }
+                    finally { done.Set(); }
+                });
+                done.Wait(TimeSpan.FromSeconds(30));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #91

Adds global unhandled exception handling so crashes on any thread produce a logged, user-visible error instead of silently terminating the process.

## Changes

### `Narabemi/Services/CrashHandler.cs` (new)
A DI-free static helper that:
1. Logs the exception via `ILogger` (best-effort; tolerates a null/broken logger)
2. Writes `crash.log` to `AppContext.BaseDirectory` for post-mortem analysis
3. Shows a minimal Avalonia `Window`-based error dialog on the UI thread (blocks until dismissed; works from background threads via `ManualResetEventSlim`)

### `Narabemi/App.axaml.cs` (modified)
- `RegisterGlobalExceptionHandlers()` — called at the top of `OnFrameworkInitializationCompleted` before any other work, subscribes to:
  - `AppDomain.CurrentDomain.UnhandledException` — CLR thread-pool / background threads
  - `TaskScheduler.UnobservedTaskException` — fire-and-forget async faults (`SetObserved()` to suppress re-throw on GC finaliser)
  - `Dispatcher.UIThread.UnhandledException` — Avalonia UI thread (`Handled = true` to suppress Avalonia re-throw)
- `InitializeDesktop()` — original body of `OnFrameworkInitializationCompleted` extracted verbatim, wrapped in `try/catch` so startup failures (missing libmpv, corrupt `appstates.json`, DI resolution errors) call `CrashHandler.Handle` + `FlushAndShutdownHost` before `Environment.Exit(1)`
- `TryGetLogger<T>()` — null-safe accessor for the DI logger; returns `null` if the host hasn't been built yet
- `FlushAndShutdownHost()` — calls `_host.StopAsync(5 s)` so ZLogger flushes its file buffer before exit

## Testing

- `dotnet build` — 0 warnings, 0 errors (warnings-as-errors enforced)
- `dotnet test` — 27/27 passed (pre-commit hook confirmed)
- Verified additive: `desktop.ShutdownRequested` handler and all other existing logic are untouched

## Wave coordination note

This PR is intentionally additive. It does not restructure `desktop.ShutdownRequested` (targeted by Wave 3 / #95) or the static `App.Services` provider (targeted by Wave 4 / #97). Both will apply cleanly on top.
