### PR TITLE
feat: add H and R keyboard shortcuts for blend mode toggle and split reset

### DIFF
--- a/Narabemi/ViewModels/MainWindowViewModel.cs
+++ b/Narabemi/ViewModels/MainWindowViewModel.cs
@@ -288,5 +288,21 @@ namespace Narabemi.ViewModels
         {
             IsMasterVolumeMuted = !IsMasterVolumeMuted;
         }
+
+        /// <summary>
+        /// Toggles <see cref="BlendMode"/> between 0 (Horizontal) and 1 (Vertical).
+        /// </summary>
+        public void ToggleBlendMode()
+        {
+            BlendMode = BlendMode == 0 ? 1 : 0;
+        }
+
+        /// <summary>
+        /// Resets <see cref="BlendRatio"/> to the centre (0.5).
+        /// </summary>
+        public void ResetSplit()
+        {
+            BlendRatio = 0.5;
+        }
     }
 }

--- a/Narabemi/Views/MainWindow.axaml.cs
+++ b/Narabemi/Views/MainWindow.axaml.cs
@@ -445,6 +445,14 @@ namespace Narabemi.Views
                     _ = OpenFileAsync(secondary);
                     e.Handled = true;
                     break;
+                case Key.H:
+                    vm.ToggleBlendMode();
+                    e.Handled = true;
+                    break;
+                case Key.R:
+                    vm.ResetSplit();
+                    e.Handled = true;
+                    break;
             }
         }
 


### PR DESCRIPTION
## Summary

- Adds `H` key to toggle blend mode between Horizontal and Vertical split
- Adds `R` key to reset the split ratio to 0.5 (centre)
- Adds `ToggleBlendMode()` and `ResetSplit()` helper methods to `MainWindowViewModel` to keep the logic reusable and out of the view

## Changes

- `Narabemi/ViewModels/MainWindowViewModel.cs` — two new public methods: `ToggleBlendMode()` and `ResetSplit()`
- `Narabemi/Views/MainWindow.axaml.cs` — two new `case` branches in `OnKeyDown`: `Key.H` and `Key.R`

Keys intentionally NOT used: `S` (reserved for #108 snapshot shortcut).

## Testing

- Build: 0 errors, 0 warnings
- Tests: 27/27 passed (pre-commit hook + manual `dotnet test`)
- Manual: launch the app, press `H` to flip between horizontal/vertical split, press `R` to centre the divider

Closes #102
