### PR TITLE
fix: remove redundant 250ms poll timer from VideoPlayerViewModel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ MainWindow (Grid: rows = "*,Auto")
 - `Mpv/MpvPlayer.cs` — High-level wrapper. `InitNativeD3D11(hwnd)` is the only init path. Background event-loop thread; `Dispose` sends `quit` and joins before `terminate_destroy` to avoid an AVE race.
 - `Mpv/MpvVideoView.cs` — Avalonia `NativeControlHost` that exposes the child HWND.
 - `UI/Controls/VideoPlayerControl.axaml` — UserControl wrapping `MpvVideoView`; calls `vm.InitMpv(hwnd)` on `HandleReady`.
-- `ViewModels/VideoPlayerViewModel.cs` — One per player; mediates `MpvPlayer` events ↔ Avalonia bindings; 250 ms poll timer keeps `Position`/`Duration`/`IsPaused` fresh.
+- `ViewModels/VideoPlayerViewModel.cs` — One per player; mediates `MpvPlayer` events ↔ Avalonia bindings. Implements `IDisposable` to unsubscribe event handlers on shutdown.
 - `ViewModels/MainWindowViewModel.cs` — `PlayerA`/`PlayerB`, `BlendMode`, `BlendRatio`, `AutoSync`, `Loop`, `MasterVolume`. `SeekBoth` / `SeekRelative` for keyboard nav.
 - `Views/MainWindow.axaml.cs` — Drag-to-split splitter handlers, drop overlay, key shortcuts (Space, Esc, ←/→, Ctrl+O / Ctrl+Shift+O).
 - `Services/ControlFadeManager.cs` + `UI/Controls/ControlFadeAnimator.cs` — Auto-hide control panel.

--- a/Narabemi/ViewModels/VideoPlayerViewModel.cs
+++ b/Narabemi/ViewModels/VideoPlayerViewModel.cs
@@ -9,12 +9,12 @@ using Narabemi.Settings;
 
 namespace Narabemi.ViewModels
 {
-    public partial class VideoPlayerViewModel : ViewModelBase, IAppStatePlayerTarget
+    public partial class VideoPlayerViewModel : ViewModelBase, IAppStatePlayerTarget, IDisposable
     {
         private readonly MpvPlayer _mpvPlayer;
         private readonly ILogger<VideoPlayerViewModel> _logger;
         private bool _mpvInitialized;
-        private DispatcherTimer? _pollTimer;
+        private bool _disposed;
 
         /// <summary>Source video pixel dimensions, populated on FileLoaded.</summary>
         public int SourceWidth { get; private set; }
@@ -79,15 +79,24 @@ namespace Narabemi.ViewModels
             _mpvPlayer = mpvPlayer;
             _logger = logger;
 
-            _mpvPlayer.PositionChanged += pos =>
-                Dispatcher.UIThread.Post(() => { if (!_isSeeking) Position = pos; });
-            _mpvPlayer.DurationChanged += dur =>
-                Dispatcher.UIThread.Post(() => Duration = dur);
-            _mpvPlayer.PauseChanged += paused =>
-                Dispatcher.UIThread.Post(() => IsPaused = paused);
-            _mpvPlayer.FileLoaded += () =>
-                Dispatcher.UIThread.Post(OnFileLoaded);
+            _mpvPlayer.PositionChanged += OnPositionChangedEvent;
+            _mpvPlayer.DurationChanged += OnDurationChangedEvent;
+            _mpvPlayer.PauseChanged += OnPauseChangedEvent;
+            _mpvPlayer.FileLoaded += OnFileLoadedEvent;
         }
+
+        // Named handlers so they can be unsubscribed in Dispose.
+        private void OnPositionChangedEvent(double pos) =>
+            Dispatcher.UIThread.Post(() => { if (!_isSeeking) Position = pos; });
+
+        private void OnDurationChangedEvent(double dur) =>
+            Dispatcher.UIThread.Post(() => Duration = dur);
+
+        private void OnPauseChangedEvent(bool paused) =>
+            Dispatcher.UIThread.Post(() => IsPaused = paused);
+
+        private void OnFileLoadedEvent() =>
+            Dispatcher.UIThread.Post(OnFileLoaded);
 
         private bool _pendingLoop;
 
@@ -110,31 +119,8 @@ namespace Narabemi.ViewModels
             if (System.Math.Abs(Speed - 1.0) > 1e-6)
                 _mpvPlayer.Speed = System.Math.Clamp(Speed, 0.1, 100.0);
 
-            _pollTimer = new DispatcherTimer(TimeSpan.FromMilliseconds(250), DispatcherPriority.Background, OnPollTimer);
-            _pollTimer.Start();
-
             if (!string.IsNullOrEmpty(VideoPath) && File.Exists(VideoPath))
                 _mpvPlayer.LoadFile(VideoPath);
-        }
-
-        private void OnPollTimer(object? sender, EventArgs e)
-        {
-            if (!_mpvInitialized) return;
-
-            var dur = _mpvPlayer.Duration;
-            if (dur > 0 && Math.Abs(dur - Duration) > 0.01)
-                Duration = dur;
-
-            if (!_isSeeking)
-            {
-                var pos = _mpvPlayer.Position;
-                if (Math.Abs(pos - Position) > 0.01)
-                    Position = pos;
-            }
-
-            var paused = _mpvPlayer.IsPaused;
-            if (paused != IsPaused)
-                IsPaused = paused;
         }
 
         partial void OnPositionChanged(double value) => OnPropertyChanged(nameof(TimeDisplay));
@@ -273,6 +259,19 @@ namespace Narabemi.ViewModels
         private void OpenFile()
         {
             // File dialog will be handled by the View (code-behind) since it needs window access
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+
+            // Unsubscribe from MpvPlayer events to prevent callbacks into a torn-down VM
+            // after shutdown begins.
+            _mpvPlayer.PositionChanged -= OnPositionChangedEvent;
+            _mpvPlayer.DurationChanged -= OnDurationChangedEvent;
+            _mpvPlayer.PauseChanged -= OnPauseChangedEvent;
+            _mpvPlayer.FileLoaded -= OnFileLoadedEvent;
         }
     }
 }


### PR DESCRIPTION
## Summary

Removes the redundant 250ms `DispatcherTimer` (`_pollTimer`) from `VideoPlayerViewModel`.

`MpvPlayer` already fires `PositionChanged`, `DurationChanged`, and `PauseChanged` events via `ObserveProperty` registrations in its background event loop. The timer was duplicating this work by re-reading the same three properties synchronously via P/Invoke on the UI thread every 250 ms — and creating a use-after-free window where a timer tick could race `MpvPlayer.Dispose()`.

## Changes

- **`Narabemi/ViewModels/VideoPlayerViewModel.cs`**
  - Remove `_pollTimer` field, `OnPollTimer` method, and timer `Start()` call from `FinishInit()`
  - Convert anonymous lambda event subscriptions to named handler methods (`OnPositionChangedEvent`, `OnDurationChangedEvent`, `OnPauseChangedEvent`, `OnFileLoadedEvent`) so they can be properly unsubscribed
  - Implement `IDisposable` to unsubscribe from `MpvPlayer` events on shutdown, closing the race with `MpvPlayer.Dispose()`
  - The DI container auto-disposes `IDisposable` singletons; no call-site changes are needed
- **`CLAUDE.md`** — Update `VideoPlayerViewModel` description to remove stale mention of poll timer and note the `IDisposable` implementation

## Testing

- `dotnet build` — 0 warnings, 0 errors
- `dotnet test` — 27/27 tests pass (also ran as pre-commit hook)

Closes #88