### PR TITLE
fix: handle HWND change when native control is re-created in MpvVideoView

### DIFF
--- a/Narabemi/Mpv/MpvPlayer.cs
+++ b/Narabemi/Mpv/MpvPlayer.cs
@@ -68,6 +68,23 @@ namespace Narabemi.Mpv
             _logger.LogInformation("mpv initialized (native d3d11, wid={WindowId})", windowId);
         }
 
+        /// <summary>
+        /// Updates libmpv's output window to a new native handle after the native control
+        /// has been re-created by Avalonia (e.g. on display reconfiguration or future
+        /// dock/undock flows). The wid property is writable at runtime; mpv will
+        /// migrate the video output to the new window on the next rendered frame.
+        /// </summary>
+        public void RebindWindow(long windowId)
+        {
+            EnsureInit();
+            var err = MpvApi.SetPropertyString(_ctx, "wid", windowId.ToString());
+            if (err < 0)
+                _logger.LogWarning("mpv wid rebind failed (err={Err}): {Msg}",
+                    err, MpvApi.GetErrorMessage(err));
+            else
+                _logger.LogInformation("mpv rebound to new wid={WindowId}", windowId);
+        }
+
         /// <summary>Returns the value of an mpv property as a string, or null if unavailable.</summary>
         public string? GetPropertyStr(string name)
         {

--- a/Narabemi/Mpv/MpvVideoView.cs
+++ b/Narabemi/Mpv/MpvVideoView.cs
@@ -14,7 +14,19 @@ namespace Narabemi.Mpv
 
         public IntPtr NativeHandle => _handle?.Handle ?? IntPtr.Zero;
 
+        /// <summary>
+        /// Raised each time Avalonia creates (or re-creates) the native control.
+        /// Callers must handle re-creation: a second fire with a different handle
+        /// means the previous HWND is already destroyed.
+        /// </summary>
         public event Action<IntPtr>? HandleReady;
+
+        /// <summary>
+        /// Raised just before Avalonia destroys the native control, carrying the
+        /// handle that is about to be invalidated. Fires before the base destroy
+        /// call so the HWND is still technically alive when handlers run.
+        /// </summary>
+        public event Action<IntPtr>? HandleDestroyed;
 
         protected override IPlatformHandle CreateNativeControlCore(IPlatformHandle parent)
         {
@@ -25,7 +37,10 @@ namespace Narabemi.Mpv
 
         protected override void DestroyNativeControlCore(IPlatformHandle control)
         {
+            var dying = _handle;
             _handle = null;
+            if (dying is not null)
+                HandleDestroyed?.Invoke(dying.Handle);
             base.DestroyNativeControlCore(control);
         }
     }

--- a/Narabemi/ViewModels/VideoPlayerViewModel.cs
+++ b/Narabemi/ViewModels/VideoPlayerViewModel.cs
@@ -15,6 +15,7 @@ namespace Narabemi.ViewModels
         private readonly ILogger<VideoPlayerViewModel> _logger;
         private bool _mpvInitialized;
         private bool _disposed;
+        private IntPtr _boundHwnd;
 
         /// <summary>Source video pixel dimensions, populated on FileLoaded.</summary>
         public int SourceWidth { get; private set; }
@@ -103,13 +104,33 @@ namespace Narabemi.ViewModels
         /// <summary>
         /// Initializes mpv with native D3D11 video output and full HW decoding,
         /// rendering directly into the provided child HWND.
+        /// <para>
+        /// Safe to call on native-control re-creation: if mpv is already bound to the
+        /// same HWND the call is a no-op; if a different HWND arrives (e.g. display
+        /// reconfiguration, future dock/undock) the wid property is updated in-place so
+        /// mpv migrates rendering without a full context restart.
+        /// </para>
         /// </summary>
         public void InitMpv(IntPtr windowHandle)
         {
-            if (_mpvInitialized) return;
+            if (!_mpvInitialized)
+            {
+                _mpvPlayer.InitNativeD3D11(windowHandle.ToInt64());
+                _boundHwnd = windowHandle;
+                FinishInit();
+                return;
+            }
 
-            _mpvPlayer.InitNativeD3D11(windowHandle.ToInt64());
-            FinishInit();
+            // Native control was re-created -- detect whether the HWND actually changed.
+            if (windowHandle == _boundHwnd)
+                return;
+
+            _logger.LogWarning(
+                "Native control re-created with a different HWND " +
+                "(old=0x{Old:X}, new=0x{New:X}); rebinding mpv wid to the new window.",
+                _boundHwnd, windowHandle);
+            _mpvPlayer.RebindWindow(windowHandle.ToInt64());
+            _boundHwnd = windowHandle;
         }
 
         private void FinishInit()


### PR DESCRIPTION
## Summary

Closes #94

When Avalonia destroys and re-creates the native control (triggered by display reconfiguration, future dock/undock flows, or XAML hot-reload), `CreateNativeControlCore` fires `HandleReady` again with a new HWND. `VideoPlayerControl` forwarded this to `InitMpv`, which silently early-returned on `_mpvInitialized`, leaving mpv bound to a destroyed window — resulting in black video with no diagnostic output.

## Changes

- **`Mpv/MpvVideoView.cs`**: Added `HandleDestroyed` event that fires (with the old handle) just before the base `DestroyNativeControlCore` call, giving subscribers a clean signal that a handle is being invalidated. Updated `HandleReady` doc comment to note that re-fires indicate the previous HWND is already gone.

- **`Mpv/MpvPlayer.cs`**: Added `RebindWindow(long windowId)` that updates libmpv's `wid` property at runtime via `mpv_set_property_string`. The `wid` property is writable post-init; mpv migrates the video output to the new window on the next rendered frame without requiring a full context restart.

- **`ViewModels/VideoPlayerViewModel.cs`**: Added `_boundHwnd` field to track the HWND mpv was last bound to. `InitMpv` now handles three cases:
  1. First call (not yet initialized): init mpv, store HWND, call `FinishInit`.
  2. Re-call with the same HWND: no-op (guard against duplicate fires).
  3. Re-call with a different HWND: log a warning with old/new HWND values and call `RebindWindow`.

## Testing

- Build: `dotnet build Narabemi/Narabemi.csproj` — 0 warnings, 0 errors
- Tests: `dotnet test Narabemi.Tests/Narabemi.Tests.csproj` — 27/27 passed

Manual verification of the re-creation path is not easily triggered in the current app (no UX flow forces a native-control destroy cycle today), but the logic can be exercised by running the bench or probe-native test modes while disconnecting/reconnecting a display.
