### PR TITLE
refactor: consolidate appstates persistence to a single owner

### DIFF
--- a/Narabemi/App.axaml.cs
+++ b/Narabemi/App.axaml.cs
@@ -165,15 +165,10 @@ namespace Narabemi
 
             desktop.MainWindow = mainWindow;
 
-            // Don't save appstates on exit in snapshot/bench mode (avoids overwriting user state)
-            if (!snapshotArgs.IsSnapshotMode && !snapshotArgs.IsBenchMode)
-            {
-                desktop.ShutdownRequested += (_, _) =>
-                {
-                    appStatesService.ApplyFrom(mainVm);
-                    appStatesService.SaveFile();
-                };
-            }
+            // Persistence on shutdown is owned by MainWindowViewModel.Closed (the single
+            // canonical save path). The duplicate ShutdownRequested handler that previously
+            // lived here was removed — the VM command already gates on
+            // IsSnapshotMode/IsBenchMode and handles the same ApplyFrom/SaveFile sequence.
 
             // Start snapshot/bench runner after window is shown
             if (snapshotArgs.IsSnapshotMode)

--- a/Narabemi/ViewModels/MainWindowViewModel.cs
+++ b/Narabemi/ViewModels/MainWindowViewModel.cs
@@ -133,7 +133,10 @@ namespace Narabemi.ViewModels
         [RelayCommand]
         private void Closed()
         {
-            if (IsSnapshotMode) return;
+            // Skip persistence in headless test modes — App used to gate this via its
+            // own ShutdownRequested handler; now that this is the single canonical save
+            // path, the gate moved here.
+            if (IsSnapshotMode || IsBenchMode) return;
             _appStatesService.ApplyFrom(this);
             _appStatesService.SaveFile();
             _logger.LogInformation("State saved to appstates.json");


### PR DESCRIPTION
## Summary

- Removes the duplicate `desktop.ShutdownRequested` handler in `App.axaml.cs` that was calling `appStatesService.ApplyFrom(mainVm)` + `SaveFile()` alongside the identical path in `MainWindowViewModel.ClosedCommand`.
- `ClosedCommand` in `MainWindowViewModel` is now the **single canonical owner** of appstates persistence; it already handled logging and snapshot-mode opt-out.
- Extends the test-mode guard in `Closed()` to also skip save when `IsBenchMode` is true — previously this was handled only by the outer `App` condition that has now been removed.

## Why VM over App

The VM command was chosen as the single owner because:
- It already had the `IsSnapshotMode` guard and logging, making it self-contained.
- `ShutdownRequested` fires after `MainWindow.Closing` anyway, so the App handler was always writing the file a second time.
- Keeping persistence decisions inside the VM keeps `App` focused on composition and lifecycle wiring only.

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — 27/27 pass (pre-commit hook)
- [ ] Manual smoke test: launch app, change blend ratio, close — verify `appstates.json` written exactly once (single log line `State saved to appstates.json`)
- [ ] Bench mode: `dotnet run -- --bench 5 --video-a <path>` — verify `appstates.json` is **not** overwritten

closes #95, closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)