### PR TITLE
feat: add S key shortcut to snapshot both players' current frame

### DIFF
--- a/Narabemi/Views/MainWindow.axaml.cs
+++ b/Narabemi/Views/MainWindow.axaml.cs
@@ -494,7 +494,37 @@ namespace Narabemi.Views
                     vm.ResetSplit();
                     e.Handled = true;
                     break;
+                case Key.S when !ctrl && !shift:
+                    SaveSnapshot(vm);
+                    e.Handled = true;
+                    break;
             }
+        }
+
+        private void SaveSnapshot(MainWindowViewModel vm)
+        {
+            // Determine output directory: prefer the folder containing PlayerA's video;
+            // fall back to Pictures if no video is loaded.
+            var videoPath = vm.PlayerA.VideoPath;
+            var outDir = !string.IsNullOrEmpty(videoPath) && File.Exists(videoPath)
+                ? Path.GetDirectoryName(videoPath) ?? Environment.GetFolderPath(Environment.SpecialFolder.MyPictures)
+                : Environment.GetFolderPath(Environment.SpecialFolder.MyPictures);
+
+            var baseName = !string.IsNullOrEmpty(videoPath)
+                ? Path.GetFileNameWithoutExtension(videoPath)
+                : "snapshot";
+
+            var timestamp = DateTime.Now.ToString("yyyyMMdd_HHmmss");
+            var pathA = Path.Combine(outDir, $"{baseName}_snapshot_{timestamp}_a.png");
+            var pathB = Path.Combine(outDir, $"{baseName}_snapshot_{timestamp}_b.png");
+
+            var retA = vm.PlayerA.MpvPlayer.SnapshotToFile(pathA);
+            if (retA != 0)
+                System.Diagnostics.Debug.WriteLine($"[Snapshot] PlayerA SnapshotToFile returned {retA} for '{pathA}'");
+
+            var retB = vm.PlayerB.MpvPlayer.SnapshotToFile(pathB);
+            if (retB != 0)
+                System.Diagnostics.Debug.WriteLine($"[Snapshot] PlayerB SnapshotToFile returned {retB} for '{pathB}'");
         }
 
         private async System.Threading.Tasks.Task OpenFileAsync(VideoPlayerViewModel target)

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ dotnet test Narabemi.Tests/Narabemi.Tests.csproj
 
 - **Open files**: drag-and-drop two video files onto the window, or use `Ctrl+O` / `Ctrl+Shift+O` to open files for player A / B individually.
 - **Drag the splitter**: the thin line between the two video panes is draggable — grab it to change the split ratio in real time.
-- **Keyboard shortcuts**: `Space` play/pause, `Esc` stop, `←` / `→` seek ±5 s (`Shift+` for ±30 s).
+- **Keyboard shortcuts**: `Space` play/pause, `Esc` stop, `←` / `→` seek ±5 s (`Shift+` for ±30 s), `S` save a snapshot of both players' current frame.
 - **Split direction**: toggle between Horizontal (side-by-side) and Vertical (stacked) via the `Horizontal/Vertical` button in the control panel.
 - **Sync** seeks both players together when enabled. **Loop** loops the current videos.
 


### PR DESCRIPTION
## Summary

- Adds `Key.S` branch in `OnKeyDown` in `MainWindow.axaml.cs` that calls the existing `MpvPlayer.SnapshotToFile` on both PlayerA and PlayerB.
- Output directory defaults to the folder containing PlayerA's loaded video; falls back to the user's Pictures folder when no video is loaded.
- Filename pattern: `{videoBaseName}_snapshot_{yyyyMMdd_HHmmss}_a.png` and `..._b.png`.
- Non-zero return codes from `SnapshotToFile` (e.g., no frame rendered yet) are logged via `Debug.WriteLine`.
- Updated README keyboard shortcuts line to document the new `S` key.

## Changes

- `Narabemi/Views/MainWindow.axaml.cs`: added `case Key.S` in `OnKeyDown` and new `SaveSnapshot(MainWindowViewModel)` helper method (~30 lines).
- `README.md`: added `S` snapshot shortcut to the keyboard shortcuts bullet.

## Testing

- `dotnet build` — 0 warnings, 0 errors.
- `dotnet test` — 27/27 tests passed.
- Key.S does not conflict with existing shortcuts (Space, Esc, ←/→, Ctrl+O, Ctrl+Shift+O) or the Wave 2 additions (H, R).

Closes #108