### PR TITLE
perf: cache static readonly Cursor fields to avoid per-call allocations

### DIFF
--- a/Narabemi/Services/ControlFadeManager.cs
+++ b/Narabemi/Services/ControlFadeManager.cs
@@ -13,6 +13,10 @@ namespace Narabemi.Services
 {
     public partial class ControlFadeManager : ObservableObject, IDisposable, IRecipient<ControlsMouseMoveMessage>, IRecipient<ControlsVisibilityMessage>
     {
+        // Cached cursor — Cursor implements IDisposable; allocating one per fade tick
+        // would leak the previous instance.
+        private static readonly Cursor CursorNone = new(StandardCursorType.None);
+
         public bool IsVisible { get; private set; } = true;
 
         private readonly TimeSpan _hideStartDuration = TimeSpan.FromMilliseconds(1000);
@@ -82,7 +86,7 @@ namespace Narabemi.Services
                     }
                     else
                     {
-                        _mouseMoveTargets.ForEach(v => v.Cursor = new Cursor(StandardCursorType.None));
+                        _mouseMoveTargets.ForEach(v => v.Cursor = CursorNone);
                     }
 
                     IsVisible = newValue;

--- a/Narabemi/Views/MainWindow.axaml.cs
+++ b/Narabemi/Views/MainWindow.axaml.cs
@@ -154,6 +154,13 @@ namespace Narabemi.Views
         private bool _layoutHorizontal = true;
         private bool _layoutInitialized;
 
+        // Cached cursors — Cursor implements IDisposable; allocating one per layout
+        // rebuild or per drag tick would leak the previous instance.
+        private static readonly Avalonia.Input.Cursor CursorSizeWestEast =
+            new(Avalonia.Input.StandardCursorType.SizeWestEast);
+        private static readonly Avalonia.Input.Cursor CursorSizeNorthSouth =
+            new(Avalonia.Input.StandardCursorType.SizeNorthSouth);
+
         /// <summary>
         /// Computes the InnerVideoGrid's pixel size (matched to source aspect) and the
         /// per-cell pixel widths/heights so the cropped video fills each cell with no
@@ -260,7 +267,7 @@ namespace Narabemi.Views
                 Grid.SetRow(a, 0);        Grid.SetColumn(a, 0);
                 Grid.SetRow(splitter, 0); Grid.SetColumn(splitter, 1);
                 Grid.SetRow(b, 0);        Grid.SetColumn(b, 2);
-                splitter.Cursor = new Avalonia.Input.Cursor(Avalonia.Input.StandardCursorType.SizeWestEast);
+                splitter.Cursor = CursorSizeWestEast;
             }
             else
             {
@@ -270,7 +277,7 @@ namespace Narabemi.Views
                 Grid.SetRow(a, 0);        Grid.SetColumn(a, 0);
                 Grid.SetRow(splitter, 1); Grid.SetColumn(splitter, 0);
                 Grid.SetRow(b, 2);        Grid.SetColumn(b, 0);
-                splitter.Cursor = new Avalonia.Input.Cursor(Avalonia.Input.StandardCursorType.SizeNorthSouth);
+                splitter.Cursor = CursorSizeNorthSouth;
             }
 
             _layoutHorizontal = horizontal;


### PR DESCRIPTION
## Overview

Eliminates three `new Cursor(...)` allocations that were previously created on every call:

- `ApplyVideoLayout` (slow path) in `MainWindow.axaml.cs` — called on every orientation rebuild, created a fresh `SizeWestEast` or `SizeNorthSouth` cursor and dropped the old one without disposing it.
- `ControlFadeManager.Receive` — created `new Cursor(StandardCursorType.None)` on every fade-out tick (fires every ~500 ms while the controls are hidden).

`Cursor` implements `IDisposable`; the previous instances were dropped on the floor each call without being disposed.

## Changes

- `Narabemi/Views/MainWindow.axaml.cs` — Add `static readonly` fields `CursorSizeWestEast` and `CursorSizeNorthSouth`; replace the two `new Cursor(...)` lines in the slow-path orientation rebuild.
- `Narabemi/Services/ControlFadeManager.cs` — Add `static readonly` field `CursorNone`; replace the `new Cursor(StandardCursorType.None)` in `Receive`.

## Testing

- Build: `dotnet build Narabemi/Narabemi.csproj` — 0 warnings, 0 errors.
- Tests: `dotnet test Narabemi.Tests/Narabemi.Tests.csproj` — 27/27 passed.

Closes #101
