### PR TITLE
refactor: remove unused IsControlPanelVisible observable property

### DIFF
--- a/Narabemi/ViewModels/MainWindowViewModel.cs
+++ b/Narabemi/ViewModels/MainWindowViewModel.cs
@@ -44,9 +44,6 @@ namespace Narabemi.ViewModels
         [ObservableProperty]
         private bool _isMasterVolumeMuted;
 
-        [ObservableProperty]
-        private bool _isControlPanelVisible = true;
-
         public VideoPlayerViewModel PlayerA { get; }
         public VideoPlayerViewModel PlayerB { get; }
 

--- a/Narabemi/ViewModels/VideoPlayerViewModel.cs
+++ b/Narabemi/ViewModels/VideoPlayerViewModel.cs
@@ -54,9 +54,6 @@ namespace Narabemi.ViewModels
         private double _timeOffset = 0.0;
 
         [ObservableProperty]
-        private bool _isControlPanelVisible = true;
-
-        [ObservableProperty]
         private string _displayInfo = string.Empty;
 
         private bool _isSeeking;


### PR DESCRIPTION
## Summary

- Removes the `[ObservableProperty] private bool _isControlPanelVisible = true;` declaration from `MainWindowViewModel` and `VideoPlayerViewModel`
- The property was never read or written by any code — control panel visibility is driven by `ControlFadeManager` / `ControlFadeAnimator` via `WeakReferenceMessenger`, not by this observable

## Changes

| File | Change |
|------|--------|
| `Narabemi/ViewModels/MainWindowViewModel.cs` | Remove 3 lines (`[ObservableProperty]` + field + blank line) |
| `Narabemi/ViewModels/VideoPlayerViewModel.cs` | Remove 3 lines (`[ObservableProperty]` + field + blank line) |

## Testing

- `grep -rn "IsControlPanelVisible" Narabemi/ Narabemi.Tests/` — zero source matches after removal (only binary build artifacts, which are stale)
- All 27 unit tests pass (`dotnet test`)

Closes #93