### PR TITLE
refactor: remove App.Services static service-locator

### DIFF
--- a/Narabemi/App.axaml.cs
+++ b/Narabemi/App.axaml.cs
@@ -32,8 +32,6 @@ namespace Narabemi
             Assembly.GetExecutingAssembly()
                 .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "0.0.0";
 
-        public static IServiceProvider Services { get; private set; } = null!;
-
         private IHost? _host;
 
         public override void Initialize()
@@ -108,17 +106,17 @@ namespace Narabemi
             var snapshotArgs = SnapshotArgs.Parse(desktop.Args);
 
             _host = CreateHostBuilder().Build();
-            Services = _host.Services;
+            var services = _host.Services;
 
             if (snapshotArgs.IsProbeNativeMode)
             {
-                var probeLogger = Services.GetRequiredService<ILogger<ProbeRunner>>();
+                var probeLogger = services.GetRequiredService<ILogger<ProbeRunner>>();
                 new ProbeRunner(snapshotArgs, probeLogger).Start();
                 base.OnFrameworkInitializationCompleted();
                 return;
             }
 
-            var appStatesService = Services.GetRequiredService<AppStatesService>();
+            var appStatesService = services.GetRequiredService<AppStatesService>();
             appStatesService.LoadFile();
 
             // In snapshot/bench mode, override video paths before ApplyTo runs
@@ -134,9 +132,9 @@ namespace Narabemi
                 }
             }
 
-            var mainWindow = Services.GetRequiredService<MainWindow>();
-            var mainVm = Services.GetRequiredService<MainWindowViewModel>();
-            var fadeManager = Services.GetRequiredService<ControlFadeManager>();
+            var mainWindow = services.GetRequiredService<MainWindow>();
+            var mainVm = services.GetRequiredService<MainWindowViewModel>();
+            var fadeManager = services.GetRequiredService<ControlFadeManager>();
 
             mainWindow.DataContext = mainVm;
             // Skip window geometry restore in headless test modes so the fixed
@@ -173,13 +171,13 @@ namespace Narabemi
             // Start snapshot/bench runner after window is shown
             if (snapshotArgs.IsSnapshotMode)
             {
-                var logger = Services.GetRequiredService<ILogger<SnapshotRunner>>();
+                var logger = services.GetRequiredService<ILogger<SnapshotRunner>>();
                 var runner = new SnapshotRunner(snapshotArgs, mainVm, logger);
                 runner.Start(mainWindow);
             }
             else if (snapshotArgs.IsBenchMode)
             {
-                var logger = Services.GetRequiredService<ILogger<BenchmarkRunner>>();
+                var logger = services.GetRequiredService<ILogger<BenchmarkRunner>>();
                 var runner = new BenchmarkRunner(snapshotArgs, mainVm, logger);
                 runner.Start();
             }


### PR DESCRIPTION
## Summary

- Removes the `public static IServiceProvider Services` property from `App` — it was a service-locator anti-pattern, violating DI best practices (mirrors closed WPF issue #20).
- Replaces all seven `Services.GetRequiredService<T>()` call sites with a local `var services = _host.Services` variable scoped to `OnFrameworkInitializationCompleted`, where the host is already built.
- No changes to `ProbeRunner`, `SnapshotRunner`, or `BenchmarkRunner` — they already accept all dependencies via constructor injection.

## Changes

- `Narabemi/App.axaml.cs`: remove static `Services` property and its assignment; introduce a local `services` variable from `_host.Services`.

## Testing

- `dotnet build` passes with 0 warnings / 0 errors.
- `dotnet test` passes: 27/27 tests green (pre-commit hook confirmed).

Closes #97