### PR TITLE
chore: remove unused Tmds.DBus.Protocol reference and dead BlendBorderWidth/Color VM surface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,14 +61,14 @@ MainWindow (Grid: rows = "*,Auto")
 - `Views/MainWindow.axaml.cs` — Drag-to-split splitter handlers, drop overlay, key shortcuts (Space, Esc, ←/→, Ctrl+O / Ctrl+Shift+O).
 - `Services/ControlFadeManager.cs` + `UI/Controls/ControlFadeAnimator.cs` — Auto-hide control panel.
 - `Settings/AppStatesService.cs` — Persists/loads `appstates.json`.
-- `Settings/ColorRgba.cs` — Platform-neutral color (kept for `BlendBorderColor` backwards-compat in saved state).
+- `Settings/ColorRgba.cs` — Platform-neutral color (kept for `AppStates.BlendBorderColor` JSON forward-compat in saved state; not exposed on the VM or interface).
 - `Testing/ProbeRunner.cs` / `BenchmarkRunner.cs` / `SnapshotRunner.cs` — CLI test harnesses (see Test Modes below).
 
 **Settings layer** (`Settings/`) has no UI framework dependency.
 
 **Configuration:**
 - `appsettings.json` — read-only (mpv directory, etc.).
-- `appstates.json` — mutable runtime state (Loop, AutoSync, MainPlayerIndex, VideoPathList, BlendMode, BlendRatio, WindowWidth/Height/X/Y, IsWindowMaximized). `BlendBorderWidth` / `BlendBorderColor` remain in the schema for forward-compat but no longer drive any UI.
+- `appstates.json` — mutable runtime state (Loop, AutoSync, MainPlayerIndex, VideoPathList, BlendMode, BlendRatio, WindowWidth/Height/X/Y, IsWindowMaximized). `BlendBorderWidth` / `BlendBorderColor` remain on the `AppStates` data class for JSON forward-compat but are not wired to the VM or interface.
 
 ## Test Modes
 

--- a/Narabemi.Tests/AppStatesServiceTests.cs
+++ b/Narabemi.Tests/AppStatesServiceTests.cs
@@ -24,8 +24,6 @@ namespace Narabemi.Tests
                 new StubPlayer(),
                 new StubPlayer(),
             };
-            public double BlendBorderWidth { get; set; }
-            public ColorRgba BlendBorderColor { get; set; }
             public double BlendRatio { get; set; }
             public int BlendMode { get; set; }
         }
@@ -65,18 +63,14 @@ namespace Narabemi.Tests
             Assert.Equal(0.5, target.StatePlayers[1].Speed);
             Assert.Equal(0.0, target.StatePlayers[0].TimeOffset);
             Assert.Equal(-1.5, target.StatePlayers[1].TimeOffset);
-            Assert.Equal(2.5, target.BlendBorderWidth);
-            Assert.Equal(new ColorRgba(255, 0, 128, 255), target.BlendBorderColor);
 
             target.Loop = false;
-            target.BlendBorderColor = new ColorRgba(0, 255, 0, 255);
             target.StatePlayers[0].Speed = 1.5;
             target.StatePlayers[1].TimeOffset = 3.0;
 
             service.ApplyFrom(target);
 
             Assert.False(service.Current.Loop);
-            Assert.Equal(new ColorRgba(0, 255, 0, 255), service.Current.BlendBorderColor);
             Assert.Equal(1.5, service.Current.PlayerSpeedList[0]);
             Assert.Equal(3.0, service.Current.PlayerTimeOffsetList[1]);
 

--- a/Narabemi/Narabemi.csproj
+++ b/Narabemi/Narabemi.csproj
@@ -29,7 +29,12 @@
     <PackageReference Include="CommunityToolkit.Diagnostics" Version="8.2.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
     <PackageReference Include="ZLogger" Version="2.5.7" />
-    <PackageReference Include="Tmds.DBus.Protocol" Version="0.92.0" />
+    <!-- Version override only: pins the transitive Tmds.DBus.Protocol dep (from Avalonia.Desktop)
+         to a vulnerability-free version. ExcludeAssets ensures nothing from this package is
+         compiled in or copied to output. -->
+    <PackageReference Include="Tmds.DBus.Protocol" Version="0.92.0">
+      <ExcludeAssets>All</ExcludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Narabemi/Settings/AppStatesService.cs
+++ b/Narabemi/Settings/AppStatesService.cs
@@ -80,8 +80,6 @@ namespace Narabemi.Settings
                 target.StatePlayers[i].Speed = Current.PlayerSpeedList[i];
             for (int i = 0; i < Math.Min(target.StatePlayers.Count, Current.PlayerTimeOffsetList.Count); i++)
                 target.StatePlayers[i].TimeOffset = Current.PlayerTimeOffsetList[i];
-            target.BlendBorderWidth = Current.BlendBorderWidth;
-            target.BlendBorderColor = Current.BlendBorderColor;
             target.BlendRatio = Current.BlendRatio;
             target.BlendMode = Current.BlendMode;
         }
@@ -99,8 +97,6 @@ namespace Narabemi.Settings
             Current.PlayerSpeedList.AddRange(target.StatePlayers.Select(p => p.Speed));
             Current.PlayerTimeOffsetList.Clear();
             Current.PlayerTimeOffsetList.AddRange(target.StatePlayers.Select(p => p.TimeOffset));
-            Current.BlendBorderWidth = target.BlendBorderWidth;
-            Current.BlendBorderColor = target.BlendBorderColor;
             Current.BlendRatio = target.BlendRatio;
             Current.BlendMode = target.BlendMode;
         }

--- a/Narabemi/Settings/IAppStateTarget.cs
+++ b/Narabemi/Settings/IAppStateTarget.cs
@@ -12,8 +12,6 @@ namespace Narabemi.Settings
         bool AutoSync { get; set; }
         int MainPlayerIndex { get; set; }
         IList<IAppStatePlayerTarget> StatePlayers { get; }
-        double BlendBorderWidth { get; set; }
-        ColorRgba BlendBorderColor { get; set; }
         double BlendRatio { get; set; }
         int BlendMode { get; set; }
     }

--- a/Narabemi/ViewModels/MainWindowViewModel.cs
+++ b/Narabemi/ViewModels/MainWindowViewModel.cs
@@ -27,12 +27,6 @@ namespace Narabemi.ViewModels
         private int _mainPlayerIndex;
 
         [ObservableProperty]
-        private double _blendBorderWidth = 1.0;
-
-        [ObservableProperty]
-        private ColorRgba _blendBorderColor = ColorRgba.White;
-
-        [ObservableProperty]
         private double _blendRatio = 0.5;
 
         [ObservableProperty]


### PR DESCRIPTION
## Summary

- **Part A**: Converts the `Tmds.DBus.Protocol` `PackageReference` to use `ExcludeAssets=All` — turns it into a pure version override that pins the transitive dep from Avalonia.Desktop to the vulnerability-free `0.92.0`, without adding any compile-time or runtime assets to the project.
- **Part B**: Removes `BlendBorderWidth` and `BlendBorderColor` from `IAppStateTarget`, the two `[ObservableProperty]` declarations in `MainWindowViewModel`, and the four `ApplyTo`/`ApplyFrom` assignments in `AppStatesService`. The properties are preserved on `AppStates` (the data class) for JSON forward-compat.
- **Tests**: Updates `StubTarget` in `AppStatesServiceTests` to drop the removed interface members and removes now-dead assertions against VM-side values. The `AppStates.BlendBorderWidth/BlendBorderColor` data-class properties are still exercised in the test.
- **Docs**: Updates `CLAUDE.md` to accurately reflect that `BlendBorderColor`/`BlendBorderWidth` remain only on the data class, not on the VM or interface.

## Changes

| File | Change |
|------|--------|
| `Narabemi/Narabemi.csproj` | Add `ExcludeAssets=All` to `Tmds.DBus.Protocol` reference |
| `Narabemi/Settings/IAppStateTarget.cs` | Remove `BlendBorderWidth` and `BlendBorderColor` members |
| `Narabemi/ViewModels/MainWindowViewModel.cs` | Remove two `[ObservableProperty]` declarations |
| `Narabemi/Settings/AppStatesService.cs` | Remove four `ApplyTo`/`ApplyFrom` assignments |
| `Narabemi.Tests/AppStatesServiceTests.cs` | Update stub target; remove dead assertions |
| `CLAUDE.md` | Clarify data-class-only scope of the border properties |

## Testing

- `dotnet build Narabemi/Narabemi.csproj` — passes, 0 warnings, 0 errors
- `dotnet test Narabemi.Tests/Narabemi.Tests.csproj` — 27/27 passed
- Pre-commit hook: all tests green

Closes #105