### PR TITLE
fix: skip offscreen position restore when secondary monitor is gone

### DIFF
--- a/Narabemi/Views/MainWindow.axaml.cs
+++ b/Narabemi/Views/MainWindow.axaml.cs
@@ -111,9 +111,18 @@ namespace Narabemi.Views
             // visible reposition flicker. Width==0 means "first run, use XAML defaults".
             if (savedState is { WindowWidth: > 0 })
             {
-                Width    = savedState.WindowWidth;
-                Height   = savedState.WindowHeight;
-                Position = new PixelPoint(savedState.WindowX, savedState.WindowY);
+                Width  = savedState.WindowWidth;
+                Height = savedState.WindowHeight;
+
+                // Only restore the saved position when enough of the window rect
+                // intersects the current display configuration. If the user unplugged
+                // a secondary monitor between sessions the window would otherwise open
+                // fully offscreen with no UI affordance to move it back.
+                var savedRect = new PixelRect(savedState.WindowX, savedState.WindowY,
+                    (int)savedState.WindowWidth, (int)savedState.WindowHeight);
+                if (IsRectSufficientlyOnScreen(savedRect))
+                    Position = new PixelPoint(savedState.WindowX, savedState.WindowY);
+
                 if (savedState.IsWindowMaximized)
                     WindowState = WindowState.Maximized;
             }
@@ -570,6 +579,36 @@ namespace Narabemi.Views
                 states.WindowX      = Position.X;
                 states.WindowY      = Position.Y;
             }
+        }
+
+        /// <summary>
+        /// Returns true when at least 25 % of <paramref name="rect"/> falls inside
+        /// the union of all current screen working areas. Below that threshold the
+        /// window is considered effectively offscreen (e.g. a secondary monitor was
+        /// disconnected) and the caller should fall back to a default position.
+        /// </summary>
+        private bool IsRectSufficientlyOnScreen(PixelRect rect)
+        {
+            const double MinVisibleFraction = 0.25;
+
+            var screens = Screens.All;
+            if (screens is null || screens.Count == 0)
+                return true; // cannot determine — assume on-screen
+
+            long intersectionArea = 0;
+            foreach (var screen in screens)
+            {
+                var wa = screen.WorkingArea;
+                var ix = Math.Max(rect.X, wa.X);
+                var iy = Math.Max(rect.Y, wa.Y);
+                var iw = Math.Min(rect.Right, wa.Right) - ix;
+                var ih = Math.Min(rect.Bottom, wa.Bottom) - iy;
+                if (iw > 0 && ih > 0)
+                    intersectionArea += (long)iw * ih;
+            }
+
+            var rectArea = (long)rect.Width * rect.Height;
+            return rectArea > 0 && intersectionArea >= (long)(rectArea * MinVisibleFraction);
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes #89

Replaces #112 (which had been incorrectly attached to the wrong head branch).

When a user closes Narabemi with the window on a secondary monitor that is later disconnected, the next launch restores the window to its saved position — which is now fully offscreen with no way to bring it back without editing `appstates.json`.

## Changes

- **`Narabemi/Views/MainWindow.axaml.cs`** — restore path now calls `IsRectSufficientlyOnScreen` before applying the saved `Position`. If less than 25 % of the saved window rect intersects the union of current screen working areas (`Screens.All`), the position restore is skipped and Avalonia centers the window on the primary screen using its default behavior. The size (`Width`/`Height`) is always restored since an invisible window size causes no usability problem.

- Added private helper `IsRectSufficientlyOnScreen(PixelRect)` that iterates `Screens.All`, sums the clipped intersection area against each screen's working area, and compares against the 25 % threshold.

## Testing

- `dotnet build` — zero warnings, zero errors
- `dotnet test` — 27/27 passed (pre-commit hook also ran clean)
- Manual: set `WindowX`/`WindowY` in `appstates.json` to a large offscreen value (e.g. `X: 9000`) and verify the window opens centered on the primary display instead of disappearing.