### PR TITLE
feat: add tooltip to VideoSplitter explaining double-click resets split to 50%

### DIFF
--- a/Narabemi/Views/MainWindow.axaml
+++ b/Narabemi/Views/MainWindow.axaml
@@ -41,7 +41,8 @@
                      fills its 1px cell; orientation is set in code-behind from BlendMode. -->
                 <Border x:Name="VideoSplitter"
                         Background="#66FFFFFF"
-                        BorderThickness="0">
+                        BorderThickness="0"
+                        ToolTip.Tip="Drag to adjust split · Double-click to reset to 50%">
                     <Border.Styles>
                         <Style Selector="Border#VideoSplitter:pointerover">
                             <Setter Property="Background" Value="#E6FFFFFF" />


### PR DESCRIPTION
## Overview

The `VideoSplitter` drag handle supports a double-click gesture to reset `BlendRatio` to 0.5, but this was completely undiscoverable. This PR adds a `ToolTip.Tip` attached property to the `VideoSplitter` Border so that hovering shows a hint.

## Changes

- `Narabemi/Views/MainWindow.axaml`: Added `ToolTip.Tip="Drag to adjust split · Double-click to reset to 50%"` to the `VideoSplitter` Border element. Avalonia's built-in tooltip mechanism handles the standard hover delay (~500 ms) automatically. No code-behind changes required.

## Testing

- Build: `dotnet build Narabemi/Narabemi.csproj` — 0 warnings, 0 errors
- Tests: `dotnet test Narabemi.Tests/Narabemi.Tests.csproj` — 28 passed, 0 failed
- Manual: hover over the splitter line between the two video players; the tooltip should appear after the standard delay

Closes #87