### PR TITLE
refactor: replace speed and volume clamp magic numbers with named constants

### DIFF
--- a/Narabemi/ViewModels/VideoPlayerViewModel.cs
+++ b/Narabemi/ViewModels/VideoPlayerViewModel.cs
@@ -17,6 +17,12 @@ namespace Narabemi.ViewModels
         private bool _disposed;
         private IntPtr _boundHwnd;
 
+        private const double MinSpeed  = 0.1;
+        private const double MaxSpeed  = 100.0;
+        private const double MinVolume = 0.0;
+        // mpv volume max of 130 intentionally exceeds 100 to allow software amplification.
+        private const double MaxVolume = 130.0;
+
         /// <summary>Source video pixel dimensions, populated on FileLoaded.</summary>
         public int SourceWidth { get; private set; }
         public int SourceHeight { get; private set; }
@@ -135,7 +141,7 @@ namespace Narabemi.ViewModels
             _mpvInitialized = true;
             _mpvPlayer.Loop = _pendingLoop;
             if (System.Math.Abs(Speed - 1.0) > 1e-6)
-                _mpvPlayer.Speed = System.Math.Clamp(Speed, 0.1, 100.0);
+                _mpvPlayer.Speed = System.Math.Clamp(Speed, MinSpeed, MaxSpeed);
 
             if (!string.IsNullOrEmpty(VideoPath) && File.Exists(VideoPath))
                 _mpvPlayer.LoadFile(VideoPath);
@@ -147,7 +153,7 @@ namespace Narabemi.ViewModels
         partial void OnSpeedChanged(double value)
         {
             if (_mpvInitialized)
-                _mpvPlayer.Speed = System.Math.Clamp(value, 0.1, 100.0);
+                _mpvPlayer.Speed = System.Math.Clamp(value, MinSpeed, MaxSpeed);
         }
 
         partial void OnVideoPathChanged(string value)
@@ -229,7 +235,7 @@ namespace Narabemi.ViewModels
             _mpvPlayer.IsMuted = muted;
 
             var volume = LocalVolume * masterVolume * 100.0;
-            _mpvPlayer.Volume = Math.Clamp(volume, 0.0, 130.0);
+            _mpvPlayer.Volume = Math.Clamp(volume, MinVolume, MaxVolume);
         }
 
         partial void OnLocalVolumeChanged(double value)


### PR DESCRIPTION
## Overview

Replaces scattered magic numbers for speed and volume clamping in
`VideoPlayerViewModel` with named private constants, eliminating the risk of
silent inconsistency if the acceptable range ever changes.

## Changes

- Added four `private const double` fields at the top of the class:
  `MinSpeed = 0.1`, `MaxSpeed = 100.0`, `MinVolume = 0.0`, `MaxVolume = 130.0`
- Replaced inline literals in `FinishInit()`, `OnSpeedChanged()`, and
  `UpdateActualVolume()` with the new constants
- Added an inline comment on `MaxVolume` explaining that mpv's 130 cap is
  intentional (it permits software amplification beyond unity gain)

## Testing

- `dotnet build` -- 0 warnings, 0 errors
- `dotnet test` -- 28/28 tests pass (pre-commit hook confirmed)

Closes #84