### PR TITLE
refactor: extract BlendRatio clamp constants to MainWindowViewModel

### DIFF
--- a/Narabemi/ViewModels/MainWindowViewModel.cs
+++ b/Narabemi/ViewModels/MainWindowViewModel.cs
@@ -26,6 +26,11 @@ namespace Narabemi.ViewModels
         [ObservableProperty]
         private int _mainPlayerIndex;
 
+        // Clamp bounds shared with MainWindow splitter drag; keep both ends away from 0/1
+        // so a zero-dimension crop is never passed to mpv.
+        public const double BlendRatioMin = 0.02;
+        public const double BlendRatioMax = 0.98;
+
         [ObservableProperty]
         private double _blendRatio = 0.5;
 
@@ -220,7 +225,7 @@ namespace Narabemi.ViewModels
             // Clamp matches MainWindow.axaml.cs:UpdateRatioFromPointer; load-bearing here
             // because programmatic setters (state restore, slider) bypass the splitter
             // drag clamp. A 0-dimension crop would be rejected by mpv.
-            var r = Math.Clamp(BlendRatio, 0.02, 0.98);
+            var r = Math.Clamp(BlendRatio, BlendRatioMin, BlendRatioMax);
 
             string crop;
             if (BlendMode == 0)              // Horizontal: split on X

--- a/Narabemi/Views/MainWindow.axaml.cs
+++ b/Narabemi/Views/MainWindow.axaml.cs
@@ -256,8 +256,8 @@ namespace Narabemi.Views
                 dispH = fitH;
             }
 
-            // Per-cell pixel sizes. Clamp [0.02, 0.98] mirrors the splitter drag clamp.
-            var r = System.Math.Clamp(ratio, 0.02, 0.98);
+            // Per-cell pixel sizes. Clamp mirrors the splitter drag clamp.
+            var r = System.Math.Clamp(ratio, MainWindowViewModel.BlendRatioMin, MainWindowViewModel.BlendRatioMax);
             var cellAFirst  = horizontal
                 ? System.Math.Round(dispW * r)
                 : System.Math.Round(dispH * r);
@@ -386,9 +386,7 @@ namespace Narabemi.Views
             if (size <= 0) return;
             var coord = horizontal ? pt.X : pt.Y;
 
-            const double minRatio = 0.02;
-            const double maxRatio = 0.98;
-            vm.BlendRatio = System.Math.Clamp(coord / size, minRatio, maxRatio);
+            vm.BlendRatio = System.Math.Clamp(coord / size, MainWindowViewModel.BlendRatioMin, MainWindowViewModel.BlendRatioMax);
         }
 
         private void OnSplitterPointerMoved(object? sender, PointerEventArgs e)
@@ -437,9 +435,7 @@ namespace Narabemi.Views
             var coord = horizontal ? p.X : p.Y;
 
             // Clamp away from the very edges so the user can always grab the splitter back.
-            const double minRatio = 0.02;
-            const double maxRatio = 0.98;
-            vm.BlendRatio = System.Math.Clamp(coord / size, minRatio, maxRatio);
+            vm.BlendRatio = System.Math.Clamp(coord / size, MainWindowViewModel.BlendRatioMin, MainWindowViewModel.BlendRatioMax);
         }
 
         private void OnLoaded(object? sender, RoutedEventArgs e)


### PR DESCRIPTION
## Summary

- Define `BlendRatioMin = 0.02` and `BlendRatioMax = 0.98` as `public const double` on `MainWindowViewModel`, the natural owner of the wipe-crop logic.
- Replace all four inline `0.02`/`0.98` literals across `MainWindow.axaml.cs` (three sites: `ApplyVideoLayout`, the Win32 drag-poll path, and the Avalonia pointer path) and `MainWindowViewModel.cs` (`ApplyCrop`) with references to the new constants.
- No behaviour change; build and tests (28/28) pass clean.

## Changes

- `Narabemi/ViewModels/MainWindowViewModel.cs` — add `BlendRatioMin`/`BlendRatioMax` constants; use them in `ApplyCrop`.
- `Narabemi/Views/MainWindow.axaml.cs` — replace three separate local const pairs / inline literals with `MainWindowViewModel.BlendRatioMin`/`BlendRatioMax`.

## Testing

- `dotnet build` — 0 warnings, 0 errors.
- `dotnet test` — 28/28 passed.

Closes #83

Co-authored-by: Claude Code <noreply@anthropic.com>