### PR TITLE
fix: log warning when ColorRgba hex parse falls back silently to White

### DIFF
--- a/Narabemi.Tests/ColorRgbaTests.cs
+++ b/Narabemi.Tests/ColorRgbaTests.cs
@@ -1,3 +1,8 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Narabemi.Settings;
 using Xunit;
 
@@ -5,6 +10,10 @@ namespace Narabemi.Tests
 {
     public class ColorRgbaTests
     {
+        // ---------------------------------------------------------------------------
+        // ColorRgba.FromHex (existing behaviour, unchanged)
+        // ---------------------------------------------------------------------------
+
         [Fact]
         public void FromHex_ParsesRRGGBB()
         {
@@ -31,6 +40,52 @@ namespace Narabemi.Tests
             Assert.Equal(ColorRgba.White, ColorRgba.FromHex("invalid"));
         }
 
+        // ---------------------------------------------------------------------------
+        // ColorRgba.TryFromHex
+        // ---------------------------------------------------------------------------
+
+        [Fact]
+        public void TryFromHex_ValidRRGGBB_ReturnsTrueAndParsedColor()
+        {
+            var ok = ColorRgba.TryFromHex("#FF8800", out var color);
+            Assert.True(ok);
+            Assert.Equal(255, color.R);
+            Assert.Equal(136, color.G);
+            Assert.Equal(0, color.B);
+            Assert.Equal(255, color.A);
+        }
+
+        [Fact]
+        public void TryFromHex_ValidAARRGGBB_ReturnsTrueAndParsedColor()
+        {
+            var ok = ColorRgba.TryFromHex("#80FF0000", out var color);
+            Assert.True(ok);
+            Assert.Equal(255, color.R);
+            Assert.Equal(0, color.G);
+            Assert.Equal(0, color.B);
+            Assert.Equal(128, color.A);
+        }
+
+        [Fact]
+        public void TryFromHex_InvalidString_ReturnsFalseAndWhite()
+        {
+            var ok = ColorRgba.TryFromHex("not-a-color", out var color);
+            Assert.False(ok);
+            Assert.Equal(ColorRgba.White, color);
+        }
+
+        [Fact]
+        public void TryFromHex_WrongLength_ReturnsFalseAndWhite()
+        {
+            var ok = ColorRgba.TryFromHex("#ABC", out var color);
+            Assert.False(ok);
+            Assert.Equal(ColorRgba.White, color);
+        }
+
+        // ---------------------------------------------------------------------------
+        // ColorRgba.ToString
+        // ---------------------------------------------------------------------------
+
         [Fact]
         public void ToString_OpaqueColor_ReturnsRRGGBB()
         {
@@ -43,6 +98,98 @@ namespace Narabemi.Tests
         {
             var c = new ColorRgba(255, 0, 0, 128);
             Assert.Equal("#80FF0000", c.ToString());
+        }
+
+        // ---------------------------------------------------------------------------
+        // ColorRgbaJsonConverter — warning behaviour via AppStatesService
+        //
+        // We verify the converter's warning path through AppStatesService.LoadFile()
+        // so the test project does not need to directly construct
+        // ColorRgbaJsonConverter with its new callback constructor.
+        // ---------------------------------------------------------------------------
+
+        /// <summary>
+        /// Minimal ILogger&lt;AppStatesService&gt; that captures warning messages.
+        /// </summary>
+        private sealed class CapturingLogger : ILogger<AppStatesService>
+        {
+            public readonly List<string> Warnings = new List<string>();
+
+            IDisposable ILogger.BeginScope<TState>(TState state) => NullScope.Instance;
+            bool ILogger.IsEnabled(LogLevel logLevel) => true;
+
+            void ILogger.Log<TState>(LogLevel logLevel, EventId eventId, TState state,
+                Exception? exception, Func<TState, Exception?, string> formatter)
+            {
+                if (logLevel >= LogLevel.Warning)
+                    Warnings.Add(formatter(state, exception));
+            }
+
+            private sealed class NullScope : IDisposable
+            {
+                public static readonly NullScope Instance = new NullScope();
+                public void Dispose() { }
+            }
+        }
+
+        /// <summary>
+        /// Writes <paramref name="json"/> as the appstates.json that
+        /// AppStatesService will read, runs LoadFile, then restores any
+        /// previous file.
+        /// </summary>
+        private static AppStatesService LoadFromJson(string json, ILogger<AppStatesService> logger)
+        {
+            // AppStatesService looks for "appstates.json" relative to the process
+            // working directory (or AppContext.BaseDirectory on old builds).
+            // We write a temp file, copy it to the expected path, load, then clean up.
+            var stateFile = Path.Combine(AppContext.BaseDirectory, "appstates.json");
+            var backup = stateFile + ".bak";
+
+            if (File.Exists(stateFile))
+                File.Copy(stateFile, backup, overwrite: true);
+
+            try
+            {
+                File.WriteAllText(stateFile, json);
+                var service = new AppStatesService(logger);
+                service.LoadFile();
+                return service;
+            }
+            finally
+            {
+                File.Delete(stateFile);
+                if (File.Exists(backup))
+                {
+                    File.Move(backup, stateFile, overwrite: true);
+                }
+            }
+        }
+
+        [Fact]
+        public void Converter_InvalidColorInJson_LogsWarningAndDefaultsToWhite()
+        {
+            var json = "{ \"BlendBorderColor\": \"not-a-color\" }";
+
+            var logger = new CapturingLogger();
+            var service = LoadFromJson(json, logger);
+
+            // The invalid color should have been replaced with White
+            Assert.Equal(ColorRgba.White, service.Current!.BlendBorderColor);
+            // And a warning should have been logged from the converter
+            Assert.Contains(logger.Warnings, w => w.Contains("ColorRgbaJsonConverter"));
+        }
+
+        [Fact]
+        public void Converter_ValidColorInJson_NoConverterWarning()
+        {
+            var json = "{ \"BlendBorderColor\": \"#FF8800\" }";
+
+            var logger = new CapturingLogger();
+            var service = LoadFromJson(json, logger);
+
+            Assert.Equal(ColorRgba.FromHex("#FF8800"), service.Current!.BlendBorderColor);
+            // No converter warning for a valid color
+            Assert.DoesNotContain(logger.Warnings, w => w.Contains("ColorRgbaJsonConverter"));
         }
     }
 }

--- a/Narabemi/Settings/AppStatesService.cs
+++ b/Narabemi/Settings/AppStatesService.cs
@@ -31,7 +31,7 @@ namespace Narabemi.Settings
         public AppStatesService(ILogger<AppStatesService> logger)
         {
             _logger = logger;
-            _opt.Converters.Add(new ColorRgbaJsonConverter());
+            _opt.Converters.Add(new ColorRgbaJsonConverter(msg => _logger.LogWarning("{Message}", msg)));
         }
 
         public void LoadFile()

--- a/Narabemi/Settings/ColorRgba.cs
+++ b/Narabemi/Settings/ColorRgba.cs
@@ -16,10 +16,21 @@ namespace Narabemi.Settings
         /// </summary>
         public static ColorRgba FromHex(string hex)
         {
+            TryFromHex(hex, out var result);
+            return result;
+        }
+
+        /// <summary>
+        /// Tries to parse a CSS-style hex string: <c>#RRGGBB</c> or <c>#AARRGGBB</c> (WPF format).
+        /// Returns <see langword="true"/> on success; <see langword="false"/> on unrecognized format,
+        /// setting <paramref name="result"/> to <see cref="White"/>.
+        /// </summary>
+        public static bool TryFromHex(string hex, out ColorRgba result)
+        {
             var s = hex.AsSpan().TrimStart('#');
             try
             {
-                return s.Length switch
+                result = s.Length switch
                 {
                     6 => new ColorRgba(
                         Convert.ToByte(s[0..2].ToString(), 16),
@@ -33,10 +44,12 @@ namespace Narabemi.Settings
                         Convert.ToByte(s[0..2].ToString(), 16)),
                     _ => White,
                 };
+                return s.Length is 6 or 8;
             }
             catch (FormatException)
             {
-                return White;
+                result = White;
+                return false;
             }
         }
 

--- a/Narabemi/Settings/ColorRgbaJsonConverter.cs
+++ b/Narabemi/Settings/ColorRgbaJsonConverter.cs
@@ -6,10 +6,45 @@ namespace Narabemi.Settings
 {
     public class ColorRgbaJsonConverter : JsonConverter<ColorRgba>
     {
+        // Called with a human-readable message whenever a value is null or
+        // fails to parse and the converter falls back to White.
+        private readonly Action<string>? _warn;
+
+        /// <summary>
+        /// Creates a converter that invokes <paramref name="warn"/> whenever a
+        /// hex value is <see langword="null"/> or cannot be parsed.
+        /// </summary>
+        public ColorRgbaJsonConverter(Action<string> warn)
+        {
+            _warn = warn;
+        }
+
+        /// <summary>
+        /// Creates a converter without a warning callback. Parse failures fall
+        /// back to <see cref="ColorRgba.White"/> silently. Prefer the overload
+        /// that accepts a callback so failures are observable.
+        /// </summary>
+        public ColorRgbaJsonConverter()
+        {
+        }
+
         public override ColorRgba Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             var s = reader.GetString();
-            return s is null ? ColorRgba.White : ColorRgba.FromHex(s);
+
+            if (s is null)
+            {
+                _warn?.Invoke($"{nameof(ColorRgbaJsonConverter)}: color value is null, defaulting to White.");
+                return ColorRgba.White;
+            }
+
+            if (!ColorRgba.TryFromHex(s, out var color))
+            {
+                _warn?.Invoke($"{nameof(ColorRgbaJsonConverter)}: invalid color value '{s}', defaulting to White.");
+                return ColorRgba.White;
+            }
+
+            return color;
         }
 
         public override void Write(Utf8JsonWriter writer, ColorRgba value, JsonSerializerOptions options) =>


### PR DESCRIPTION
## Summary

- Add `ColorRgba.TryFromHex()` that returns `false` on null/unrecognized input instead of silently returning `White`
- Refactor `ColorRgba.FromHex()` to delegate to `TryFromHex()`, eliminating duplicated parse logic
- Give `ColorRgbaJsonConverter` an optional `Action<string>` warn callback; `AppStatesService` wires its `ILogger` into it so any invalid color in `appstates.json` now produces a visible warning log entry
- Add `ColorRgbaTests` covering `TryFromHex` variants and the end-to-end warning path through `AppStatesService`

## Changes

| File | Change |
|------|--------|
| `Narabemi/Settings/ColorRgba.cs` | Added `TryFromHex`; `FromHex` now delegates to it |
| `Narabemi/Settings/ColorRgbaJsonConverter.cs` | New `Action<string> warn` constructor; `Read()` calls `TryFromHex` and invokes callback on failure |
| `Narabemi/Settings/AppStatesService.cs` | Pass `msg => _logger.LogWarning(...)` lambda to the converter |
| `Narabemi.Tests/ColorRgbaTests.cs` | New test file — `FromHex`, `TryFromHex`, `ToString`, converter warning tests |

## Test plan

- [x] `dotnet test` — 12 tests pass (0 failures)
- [x] `dotnet build` — 0 errors, warnings-as-errors clean
- Manual: open the app, manually edit `appstates.json` to set `"BlendBorderColor": "bad"`, relaunch — confirm a `WARN` log entry appears and the color resets to White

Closes #82

Generated with [Claude Code](https://claude.com/claude-code)
