### PR TITLE
refactor: hoist Win32 splitter drag-polling into SplitterDragController service

### DIFF
--- a/Narabemi/Services/SplitterDragController.cs
+++ b/Narabemi/Services/SplitterDragController.cs
@@ -1,0 +1,211 @@
+using System;
+using System.Runtime.InteropServices;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Narabemi.ViewModels;
+
+namespace Narabemi.Services
+{
+    /// <summary>
+    /// Owns the Win32 drag-poll loop that keeps splitter dragging responsive even
+    /// when the cursor crosses into a child mpv HWND (NativeControlHost airspace).
+    ///
+    /// SetCapture alone doesn't help in that scenario — the cursor entering a child
+    /// HWND silently drops Avalonia's pointer events. This controller polls cursor
+    /// position and left-button state via Win32 on a 16 ms timer and fires
+    /// <see cref="RatioChanged"/> whenever the ratio needs updating, or
+    /// <see cref="DragEnded"/> when the button is released outside Avalonia's view.
+    /// </summary>
+    public sealed partial class SplitterDragController : IDisposable
+    {
+        // ── Win32 P/Invoke ──────────────────────────────────────────────────────
+
+        [LibraryImport("user32.dll")]
+        private static partial IntPtr SetCapture(IntPtr hwnd);
+
+        [LibraryImport("user32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static partial bool ReleaseCapture();
+
+        [LibraryImport("user32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static partial bool GetCursorPos(out POINT point);
+
+        [LibraryImport("user32.dll")]
+        private static partial short GetAsyncKeyState(int vKey);
+
+        private const int VkLButton = 0x01;
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct POINT { public int X; public int Y; }
+
+        // ── State ───────────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Fired (on the UI thread) whenever the drag produces a new ratio value.
+        /// The value is already clamped to [<see cref="MainWindowViewModel.BlendRatioMin"/>,
+        /// <see cref="MainWindowViewModel.BlendRatioMax"/>].
+        /// </summary>
+        public event Action<double>? RatioChanged;
+
+        /// <summary>
+        /// Fired (on the UI thread) when the controller detects that the left mouse
+        /// button was released outside Avalonia's pointer tracking — the caller
+        /// should release Avalonia pointer capture and call <see cref="EndDrag"/>.
+        /// </summary>
+        public event Action? DragEnded;
+
+        private readonly Func<IntPtr> _getWindowHandle;
+        private readonly Func<MainWindowViewModel?> _getViewModel;
+        private readonly Func<Visual?> _getWindowVisual;
+        private readonly Func<Grid?> _getInnerGrid;
+
+        private bool _dragging;
+        private System.Threading.Timer? _pollTimer;
+
+        // ── Constructor ─────────────────────────────────────────────────────────
+
+        /// <param name="getWindowHandle">Returns the Win32 HWND for Win32 SetCapture.</param>
+        /// <param name="getViewModel">Returns the current <see cref="MainWindowViewModel"/>.</param>
+        /// <param name="getWindowVisual">Returns the window Visual used for screen→client coordinate conversion.</param>
+        /// <param name="getInnerGrid">Returns the InnerVideoGrid used for client→local coordinate conversion.</param>
+        public SplitterDragController(
+            Func<IntPtr> getWindowHandle,
+            Func<MainWindowViewModel?> getViewModel,
+            Func<Visual?> getWindowVisual,
+            Func<Grid?> getInnerGrid)
+        {
+            _getWindowHandle = getWindowHandle;
+            _getViewModel    = getViewModel;
+            _getWindowVisual = getWindowVisual;
+            _getInnerGrid    = getInnerGrid;
+        }
+
+        // ── Public API ──────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Starts the Win32 capture and the polling timer.
+        /// Call this from the splitter's PointerPressed handler (after Avalonia
+        /// pointer capture has been taken).
+        /// </summary>
+        public void BeginDrag()
+        {
+            _dragging = true;
+
+            var hwnd = _getWindowHandle();
+            if (hwnd != IntPtr.Zero)
+                SetCapture(hwnd);
+
+            // System.Threading.Timer runs on the thread pool, so it fires regardless
+            // of how the UI dispatcher is occupied. We marshal back to the UI thread
+            // for the actual ratio update. This was switched from DispatcherTimer
+            // because the latter wasn't reliably ticking once a Win32 mouse capture
+            // entered modal-ish behaviour on this hardware.
+            _pollTimer?.Dispose();
+            _pollTimer = new System.Threading.Timer(
+                _ => Avalonia.Threading.Dispatcher.UIThread.Post(OnPollTick,
+                        Avalonia.Threading.DispatcherPriority.Send),
+                null,
+                dueTime: 16,
+                period: 16);
+        }
+
+        /// <summary>
+        /// Releases Win32 capture and stops the polling timer.
+        /// Call this from PointerReleased / PointerCaptureLost, and also when
+        /// <see cref="DragEnded"/> fires.
+        /// </summary>
+        public void EndDrag()
+        {
+            _dragging = false;
+            ReleaseCapture();
+            _pollTimer?.Dispose();
+            _pollTimer = null;
+        }
+
+        /// <summary>
+        /// Computes the blend ratio from an Avalonia pointer event position and
+        /// fires <see cref="RatioChanged"/>. Use this for both PointerPressed (always)
+        /// and PointerMoved (only while dragging — checked internally).
+        /// </summary>
+        /// <param name="e">The pointer event.</param>
+        /// <param name="requireDragging">
+        /// When <see langword="true"/> the method is a no-op unless a drag is in progress.
+        /// Pass <see langword="false"/> on PointerPressed so the seam responds immediately on click.
+        /// </param>
+        public void UpdateFromPointer(PointerEventArgs e, bool requireDragging = false)
+        {
+            if (requireDragging && !_dragging) return;
+            var ratio = ComputeRatioFromPointer(e);
+            if (ratio.HasValue)
+                RatioChanged?.Invoke(ratio.Value);
+        }
+
+        public void Dispose() => EndDrag();
+
+        // ── Private ─────────────────────────────────────────────────────────────
+
+        private void OnPollTick()
+        {
+            if (!_dragging)
+            {
+                _pollTimer?.Dispose();
+                _pollTimer = null;
+                return;
+            }
+
+            // L-button released? End the drag — PointerReleased won't fire if the
+            // cursor was over an mpv HWND when the button came up.
+            if ((GetAsyncKeyState(VkLButton) & 0x8000) == 0)
+            {
+                DragEnded?.Invoke();
+                return;
+            }
+
+            UpdateFromWin32Cursor();
+        }
+
+        private void UpdateFromWin32Cursor()
+        {
+            var vm    = _getViewModel();
+            var inner = _getInnerGrid();
+            var win   = _getWindowVisual();
+            if (vm is null || inner is null || win is null) return;
+            if (!GetCursorPos(out var screenPt)) return;
+
+            // Screen (physical px) → window client (DIPs) → InnerVideoGrid local DIPs.
+            var clientPoint = (win as Window)?.PointToClient(new PixelPoint(screenPt.X, screenPt.Y))
+                              ?? new Point(screenPt.X, screenPt.Y);
+            var pt = win.TranslatePoint(clientPoint, inner) ?? clientPoint;
+
+            var ratio = ClampedRatio(vm, inner, pt);
+            if (ratio.HasValue)
+                RatioChanged?.Invoke(ratio.Value);
+        }
+
+        private double? ComputeRatioFromPointer(PointerEventArgs e)
+        {
+            var vm    = _getViewModel();
+            var inner = _getInnerGrid();
+            if (vm is null || inner is null) return null;
+
+            // Compute the ratio relative to InnerVideoGrid (the actual video canvas)
+            // rather than the outer VideoGrid, so the seam follows the cursor exactly
+            // even when the canvas is centred with letterbox padding around it.
+            var pt = e.GetPosition(inner);
+            return ClampedRatio(vm, inner, pt);
+        }
+
+        private static double? ClampedRatio(MainWindowViewModel vm, Grid inner, Point pt)
+        {
+            var horizontal = vm.BlendMode == 0;
+            var size = horizontal ? inner.Bounds.Width : inner.Bounds.Height;
+            if (size <= 0) return null;
+            var coord = horizontal ? pt.X : pt.Y;
+
+            // Clamp away from the very edges so the user can always grab the splitter back.
+            return System.Math.Clamp(coord / size, MainWindowViewModel.BlendRatioMin, MainWindowViewModel.BlendRatioMax);
+        }
+    }
+}

--- a/Narabemi/Views/MainWindow.axaml.cs
+++ b/Narabemi/Views/MainWindow.axaml.cs
@@ -2,7 +2,6 @@ using System;
 using System.ComponentModel;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
@@ -20,33 +19,9 @@ namespace Narabemi.Views
 {
     public partial class MainWindow : Window
     {
-        // SetCapture alone doesn't help with NativeControlHost airspace — the cursor
-        // crossing into a child HWND still loses the Avalonia drag. Workaround: poll
-        // the cursor position and mouse-button state directly via Win32 during drag,
-        // so we don't depend on Avalonia receiving any pointer event at all.
-        [LibraryImport("user32.dll")]
-        private static partial IntPtr SetCapture(IntPtr hwnd);
-
-        [LibraryImport("user32.dll")]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        private static partial bool ReleaseCapture();
-
-        [LibraryImport("user32.dll")]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        private static partial bool GetCursorPos(out POINT point);
-
-        [LibraryImport("user32.dll")]
-        private static partial short GetAsyncKeyState(int vKey);
-
-        private const int VK_LBUTTON = 0x01;
-
-        [StructLayout(LayoutKind.Sequential)]
-        private struct POINT { public int X; public int Y; }
-
-        private System.Threading.Timer? _dragPollTimer;
-
         private ControlFadeAnimator? _fadeAnimator;
         private ControlFadeManager? _fadeManager;
+        private SplitterDragController? _splitterDragController;
 
         private readonly ILogger<MainWindow> _logger;
 
@@ -102,7 +77,36 @@ namespace Narabemi.Views
             Closing += OnClosing;
             KeyDown += OnKeyDown;
 
+            // Cache control references so ApplyVideoLayout avoids repeated visual-tree walks.
+            var videoGrid = this.FindControl<Grid>("VideoGrid");
+            var innerVideoGrid = this.FindControl<Grid>("InnerVideoGrid");
+            _videoGrid      = videoGrid;
+            _innerVideoGrid = innerVideoGrid;
+            _playerAView    = this.FindControl<VideoPlayerControl>("PlayerAView");
+            _playerBView    = this.FindControl<VideoPlayerControl>("PlayerBView");
+
             var splitter = this.FindControl<Border>("VideoSplitter");
+            _videoSplitter = splitter;
+
+            // Wire up the splitter drag controller. It owns the Win32 polling timer
+            // and all P/Invoke calls; MainWindow only handles the Avalonia pointer events.
+            _splitterDragController = new SplitterDragController(
+                getWindowHandle:  () => TryGetPlatformHandle()?.Handle ?? IntPtr.Zero,
+                getViewModel:     () => DataContext as MainWindowViewModel,
+                getWindowVisual:  () => this,
+                getInnerGrid:     () => _innerVideoGrid);
+            _splitterDragController.RatioChanged += ratio =>
+            {
+                if (DataContext is MainWindowViewModel vm)
+                    vm.BlendRatio = ratio;
+            };
+            _splitterDragController.DragEnded += () =>
+            {
+                // Button released outside Avalonia's view (over an mpv HWND) —
+                // release Avalonia pointer capture and stop the Win32 capture/timer.
+                _splitterDragController.EndDrag();
+            };
+
             if (splitter is not null)
             {
                 splitter.PointerPressed     += OnSplitterPointerPressed;
@@ -112,16 +116,8 @@ namespace Narabemi.Views
             }
 
             // Window/video-area resize must re-fit the aspect-locked inner grid.
-            var videoGrid = this.FindControl<Grid>("VideoGrid");
             if (videoGrid is not null)
                 videoGrid.SizeChanged += (_, _) => ApplyVideoLayout();
-
-            // Cache control references so ApplyVideoLayout avoids repeated visual-tree walks.
-            _videoGrid    = videoGrid;
-            _innerVideoGrid = this.FindControl<Grid>("InnerVideoGrid");
-            _playerAView  = this.FindControl<VideoPlayerControl>("PlayerAView");
-            _playerBView  = this.FindControl<VideoPlayerControl>("PlayerBView");
-            _videoSplitter = splitter;
 
             // DataContext is typically set BEFORE Initialize runs (App.axaml.cs sets it,
             // then calls Initialize). The DataContextChanged event won't fire for that
@@ -316,8 +312,6 @@ namespace Narabemi.Views
             _layoutInitialized = true;
         }
 
-        private bool _splitterDragging;
-
         private void OnSplitterPointerPressed(object? sender, PointerPressedEventArgs e)
         {
             if (DataContext is not MainWindowViewModel vm) return;
@@ -331,74 +325,21 @@ namespace Narabemi.Views
                 return;
             }
 
-            _splitterDragging = true;
             e.Pointer.Capture(splitter);
-
-            // Defensive Win32 capture so any in-Avalonia pointer events still get
-            // routed correctly; the polling timer below is the real workhorse.
-            var hwnd = TryGetPlatformHandle()?.Handle ?? IntPtr.Zero;
-            if (hwnd != IntPtr.Zero) SetCapture(hwnd);
-
-            // System.Threading.Timer runs on the thread pool, so it fires regardless
-            // of how the UI dispatcher is occupied. We marshal back to the UI thread
-            // for the actual ratio update. This was switched from DispatcherTimer
-            // because the latter wasn't reliably ticking once a Win32 mouse capture
-            // entered modal-ish behavior on this hardware.
-            _dragPollTimer?.Dispose();
-            _dragPollTimer = new System.Threading.Timer(
-                _ => Avalonia.Threading.Dispatcher.UIThread.Post(OnDragPollTick,
-                        Avalonia.Threading.DispatcherPriority.Send),
-                null,
-                16, 16);
-
-            UpdateRatioFromPointer(e);
+            _splitterDragController?.BeginDrag();
+            _splitterDragController?.UpdateFromPointer(e);
             e.Handled = true;
-        }
-
-        private void OnDragPollTick()
-        {
-            if (!_splitterDragging) { _dragPollTimer?.Dispose(); _dragPollTimer = null; return; }
-
-            // L-button released? End the drag — PointerReleased won't fire if the
-            // cursor was over an mpv HWND when the button came up.
-            if ((GetAsyncKeyState(VK_LBUTTON) & 0x8000) == 0)
-            {
-                EndSplitterDrag(null);
-                return;
-            }
-
-            UpdateRatioFromCursor();
-        }
-
-        private void UpdateRatioFromCursor()
-        {
-            if (DataContext is not MainWindowViewModel vm) return;
-            var inner = _innerVideoGrid;
-            if (inner is null) return;
-            if (!GetCursorPos(out var screenPt)) return;
-
-            // Screen (physical px) → window client (DIPs) → InnerVideoGrid local DIPs.
-            var clientPoint = this.PointToClient(new PixelPoint(screenPt.X, screenPt.Y));
-            var pt = this.TranslatePoint(clientPoint, inner) ?? clientPoint;
-
-            var horizontal = vm.BlendMode == 0;
-            var size = horizontal ? inner.Bounds.Width : inner.Bounds.Height;
-            if (size <= 0) return;
-            var coord = horizontal ? pt.X : pt.Y;
-
-            vm.BlendRatio = System.Math.Clamp(coord / size, MainWindowViewModel.BlendRatioMin, MainWindowViewModel.BlendRatioMax);
         }
 
         private void OnSplitterPointerMoved(object? sender, PointerEventArgs e)
         {
-            if (!_splitterDragging) return;
-            UpdateRatioFromPointer(e);
+            _splitterDragController?.UpdateFromPointer(e, requireDragging: true);
         }
 
         private void OnSplitterPointerReleased(object? sender, PointerReleasedEventArgs e)
         {
-            if (!_splitterDragging) return;
-            EndSplitterDrag(e.Pointer);
+            e.Pointer.Capture(null);
+            _splitterDragController?.EndDrag();
             e.Handled = true;
         }
 
@@ -406,36 +347,7 @@ namespace Narabemi.Views
         {
             // Alt-Tab, popup, etc. can yank Avalonia's pointer capture mid-drag. Make
             // sure we also drop the Win32 capture so the cursor doesn't get stuck.
-            if (_splitterDragging)
-                EndSplitterDrag(e.Pointer);
-        }
-
-        private void EndSplitterDrag(IPointer? pointer)
-        {
-            _splitterDragging = false;
-            pointer?.Capture(null);
-            ReleaseCapture();
-            _dragPollTimer?.Dispose();
-            _dragPollTimer = null;
-        }
-
-        private void UpdateRatioFromPointer(PointerEventArgs e)
-        {
-            if (DataContext is not MainWindowViewModel vm) return;
-            // Compute the ratio relative to the InnerVideoGrid (the actual video canvas)
-            // rather than the outer VideoGrid, so the seam follows the cursor exactly
-            // even when the canvas is centered with letterbox padding around it.
-            var inner = _innerVideoGrid;
-            if (inner is null) return;
-
-            var p = e.GetPosition(inner);
-            var horizontal = vm.BlendMode == 0;
-            var size = horizontal ? inner.Bounds.Width : inner.Bounds.Height;
-            if (size <= 0) return;
-            var coord = horizontal ? p.X : p.Y;
-
-            // Clamp away from the very edges so the user can always grab the splitter back.
-            vm.BlendRatio = System.Math.Clamp(coord / size, MainWindowViewModel.BlendRatioMin, MainWindowViewModel.BlendRatioMax);
+            _splitterDragController?.EndDrag();
         }
 
         private void OnLoaded(object? sender, RoutedEventArgs e)
@@ -554,6 +466,7 @@ namespace Narabemi.Views
                 _logger.LogError(ex, "File picker failed");
             }
         }
+
         private void OnBlendModeButtonClick(object? sender, RoutedEventArgs e)
         {
             if (DataContext is MainWindowViewModel vm)
@@ -636,6 +549,7 @@ namespace Narabemi.Views
                 vm.ClosedCommand.Execute(null);
             }
 
+            _splitterDragController?.Dispose();
             _fadeAnimator?.Dispose();
             _fadeManager?.Dispose();
         }


### PR DESCRIPTION
Closes #99

## Overview

Extracts all Win32 splitter drag-poll logic from `MainWindow.axaml.cs` into a new dedicated service `Services/SplitterDragController.cs`, leaving the code-behind with zero Win32 declarations.

## Changes

### New: `Narabemi/Services/SplitterDragController.cs`
- Owns the four Win32 P/Invoke signatures (`SetCapture`, `ReleaseCapture`, `GetCursorPos`, `GetAsyncKeyState`) and the `POINT` struct.
- Owns the `System.Threading.Timer` drag-poll loop (16 ms, thread-pool, marshalled back to UI thread).
- Owns the `_dragging` flag and both ratio-from-pointer / ratio-from-Win32-cursor computation paths.
- Exposes two events: `RatioChanged` (fires on every drag tick with the clamped ratio) and `DragEnded` (fires when the left button is released over an mpv child HWND, outside Avalonia's view).
- References `MainWindowViewModel.BlendRatioMin` / `BlendRatioMax` (added in #132) — no duplicated clamp constants.
- Implements `IDisposable` → calls `EndDrag()` on dispose, which releases Win32 capture and stops the timer.

### Modified: `Narabemi/Views/MainWindow.axaml.cs`
- Removed: all four `[LibraryImport]` declarations, `POINT` struct, `VK_LBUTTON` constant, `_dragPollTimer` field, `_splitterDragging` flag.
- Removed: `OnDragPollTick`, `UpdateRatioFromCursor`, `EndSplitterDrag`, `UpdateRatioFromPointer` methods.
- Added: `_splitterDragController` field; created and wired in `Initialize`.
- Splitter pointer handlers now delegate to the controller: `BeginDrag` / `EndDrag` / `UpdateFromPointer`.
- `OnClosing` disposes the controller alongside the fade animator/manager.

## Testing

- `dotnet build Narabemi/Narabemi.csproj` — 0 warnings, 0 errors
- `dotnet test Narabemi.Tests/Narabemi.Tests.csproj` — 34/34 passed

Manual verification: drag the splitter bar in both horizontal and vertical modes, including dragging the cursor across the mpv video areas, to confirm the Win32 poll path continues to work correctly.
