### PR TITLE
fix: correct stale '1px splitter' comment in MainWindow.axaml

### DIFF
--- a/Narabemi/Views/MainWindow.axaml
+++ b/Narabemi/Views/MainWindow.axaml
@@ -35,10 +35,11 @@
                   VerticalAlignment="Center">
                 <controls:VideoPlayerControl x:Name="PlayerAView"
                                              DataContext="{Binding PlayerA}" />
-                <!-- The splitter cell is exactly 1px wide (= the visible line). Wider hit
-                     zones leak the parent's background through any transparent gap, so we
-                     trade hit-area forgiveness for a clean 1px visual. The single Border
-                     fills its 1px cell; orientation is set in code-behind from BlendMode. -->
+                <!-- The splitter cell is 4px wide (SplitterPx in code-behind). 1px was too
+                     narrow to click reliably at HiDPI — PointerPressed never fired and the
+                     drag never started. The Border fills the entire cell with a single
+                     semi-transparent fill so there are no transparent gaps that would leak
+                     the parent's black background. Orientation is set from BlendMode. -->
                 <Border x:Name="VideoSplitter"
                         Background="#66FFFFFF"
                         BorderThickness="0"


### PR DESCRIPTION
## Summary

- The XAML comment above `VideoSplitter` in `MainWindow.axaml` claimed the splitter cell was "exactly 1px wide" and gave inverted reasoning (implying narrow = good trade-off).
- The actual constant `SplitterPx` in `MainWindow.axaml.cs` is `4.0`, chosen because 1px was too narrow to receive click events at HiDPI (`PointerPressed` never fired, so drag never started).
- Updated the comment to state the correct 4px width, reference `SplitterPx`, and accurately explain the HiDPI hit-area motivation.

## Changes

- `Narabemi/Views/MainWindow.axaml` — comment-only update (4 lines replaced with 5 lines). No XAML elements, attributes, or behavior changed.

## Testing

- Build: `dotnet build Narabemi/Narabemi.csproj` — 0 warnings, 0 errors.
- Tests: `dotnet test Narabemi.Tests/Narabemi.Tests.csproj` — 50/50 passed.
- Pre-commit hook (test suite) passed on commit.

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)