### PR TITLE
fix: route local volume/mute changes through master state

### DIFF
--- a/Narabemi.Tests/MainWindowViewModelTests.cs
+++ b/Narabemi.Tests/MainWindowViewModelTests.cs
@@ -228,5 +228,82 @@ namespace Narabemi.Tests
             vm.BlendMode = 1;
             Assert.Equal("Vertical", vm.BlendModeLabel);
         }
+
+        // --- Local volume / mute routing through master state (Issue #138) ---
+
+        /// <summary>
+        /// Changing PlayerA's local volume must call UpdateActualVolume with the
+        /// current MasterVolume — not the old hard-coded 1.0.
+        /// We verify the effective volume by inspecting the computed formula:
+        /// LocalVolume * MasterVolume * 100.  Because mpv is not initialized in
+        /// unit tests, UpdateActualVolume is a no-op on the player side, but the
+        /// method must not throw and the formula path is exercised.
+        /// </summary>
+        [Fact]
+        public void LocalVolume_Change_DoesNotThrow_WhenMasterVolumeIsNonDefault()
+        {
+            var vm = CreateViewModel();
+            vm.MasterVolume = 0.5;
+
+            // Changing local volume must not throw even with a non-default master.
+            var ex = Record.Exception(() => vm.PlayerA.LocalVolume = 0.8);
+            Assert.Null(ex);
+        }
+
+        [Fact]
+        public void LocalVolume_Change_PlayerB_DoesNotThrow_WhenMasterVolumeIsNonDefault()
+        {
+            var vm = CreateViewModel();
+            vm.MasterVolume = 0.3;
+
+            var ex = Record.Exception(() => vm.PlayerB.LocalVolume = 0.6);
+            Assert.Null(ex);
+        }
+
+        [Fact]
+        public void IsLocalVolumeMuted_Change_DoesNotThrow_WhenMasterMuteIsOn()
+        {
+            var vm = CreateViewModel();
+            vm.IsMasterVolumeMuted = true;
+
+            // Toggling local mute while master-mute is on must not throw.
+            var ex = Record.Exception(() => vm.PlayerA.IsLocalVolumeMuted = true);
+            Assert.Null(ex);
+        }
+
+        [Fact]
+        public void IsLocalVolumeMuted_Change_PlayerB_DoesNotThrow_WhenMasterMuteIsOn()
+        {
+            var vm = CreateViewModel();
+            vm.IsMasterVolumeMuted = true;
+
+            var ex = Record.Exception(() => vm.PlayerB.IsLocalVolumeMuted = true);
+            Assert.Null(ex);
+        }
+
+        [Fact]
+        public void LocalVolume_Change_PreservesMasterVolumeSetting()
+        {
+            var vm = CreateViewModel();
+            vm.MasterVolume = 0.5;
+
+            // After a local-volume change the master volume property must be unchanged.
+            vm.PlayerA.LocalVolume = 0.8;
+
+            Assert.Equal(0.5, vm.MasterVolume);
+        }
+
+        [Fact]
+        public void IsLocalVolumeMuted_Change_PreservesMasterMuteSetting()
+        {
+            var vm = CreateViewModel();
+            vm.IsMasterVolumeMuted = true;
+
+            // Toggling local mute must not clear the master-mute flag.
+            vm.PlayerA.IsLocalVolumeMuted = true;
+            vm.PlayerA.IsLocalVolumeMuted = false;
+
+            Assert.True(vm.IsMasterVolumeMuted);
+        }
     }
 }

--- a/Narabemi/ViewModels/MainWindowViewModel.cs
+++ b/Narabemi/ViewModels/MainWindowViewModel.cs
@@ -100,6 +100,12 @@ namespace Narabemi.ViewModels
                         SyncPlaybackState();
                     if (e.PropertyName == nameof(VideoPlayerViewModel.VideoPath))
                         OnPropertyChanged(nameof(WindowTitle));
+                    // Route local-volume / local-mute changes back through master state so
+                    // the effective mpv volume is always LocalVolume * MasterVolume, not
+                    // LocalVolume * 1.0 (the old hard-coded default in VideoPlayerViewModel).
+                    if (e.PropertyName is nameof(VideoPlayerViewModel.LocalVolume)
+                                       or nameof(VideoPlayerViewModel.IsLocalVolumeMuted))
+                        player.UpdateActualVolume(MasterVolume, IsMasterVolumeMuted);
                 };
             }
 

--- a/Narabemi/ViewModels/VideoPlayerViewModel.cs
+++ b/Narabemi/ViewModels/VideoPlayerViewModel.cs
@@ -238,16 +238,6 @@ namespace Narabemi.ViewModels
             _mpvPlayer.Volume = Math.Clamp(volume, MinVolume, MaxVolume);
         }
 
-        partial void OnLocalVolumeChanged(double value)
-        {
-            UpdateActualVolume(1.0, false);
-        }
-
-        partial void OnIsLocalVolumeMutedChanged(bool value)
-        {
-            UpdateActualVolume(1.0, false);
-        }
-
         private void OnFileLoaded()
         {
             var path = _mpvPlayer.Duration > 0


### PR DESCRIPTION
Closes #138

## Overview

`VideoPlayerViewModel.OnLocalVolumeChanged` and `OnIsLocalVolumeMutedChanged` were calling `UpdateActualVolume(1.0, false)`, hard-coding master volume to 1.0 and master mute to false. This silently dropped the real master state every time a per-player local volume slider or local mute toggle was touched.

## Changes

### `Narabemi/ViewModels/VideoPlayerViewModel.cs`
- Removed `OnLocalVolumeChanged` and `OnIsLocalVolumeMutedChanged` partial methods that hard-coded `1.0, false`.

### `Narabemi/ViewModels/MainWindowViewModel.cs`
- In the existing `PropertyChanged` subscription loop for `PlayerA`/`PlayerB`, added handling for `LocalVolume` and `IsLocalVolumeMuted` property names.
- When either fires, calls `player.UpdateActualVolume(MasterVolume, IsMasterVolumeMuted)` — the same pattern already used by `OnMasterVolumeChanged` and `OnIsMasterVolumeMutedChanged`.

### `Narabemi.Tests/MainWindowViewModelTests.cs`
- Added six tests under `Local volume / mute routing through master state (Issue #138)` covering:
  - `LocalVolume` change on PlayerA and PlayerB with non-default master volume.
  - `IsLocalVolumeMuted` change on PlayerA and PlayerB with master mute on.
  - Regression checks that `MasterVolume` and `IsMasterVolumeMuted` are unchanged after local-player property changes.

## Testing

All 56 tests pass (`dotnet test Narabemi.Tests/Narabemi.Tests.csproj`).

Manual verification: set master volume to 0.5, drag a per-player local volume slider — the effective mpv volume should now be `LocalVolume * 0.5 * 100` instead of reverting to `LocalVolume * 1.0 * 100`.
